### PR TITLE
don't output `~` for empty srcs

### DIFF
--- a/bin/pkg-build
+++ b/bin/pkg-build
@@ -77,8 +77,6 @@ for PKG in $PKGS; do
     if test -f "$ZIP"; then
       GH_SRCS="$GH_SRCS ${ZIP#"$TEA_PREFIX"/}"
       GH_SRCS_RELATIVE_PATHS="$GH_SRCS_RELATIVE_PATHS ${ZIP#"$TEA_PREFIX"/}"
-    else
-      GH_SRCS="$GH_SRCS ~"
     fi
   fi
 done


### PR DESCRIPTION
I believe this to be a regression. See: https://github.com/teaxyz/pantry.core/actions/runs/4316867792/jobs/7533236794