### PR TITLE
audit.ts: support provides: ["bin/python{{version.marketing}}"]

### DIFF
--- a/libexec/audit.ts
+++ b/libexec/audit.ts
@@ -19,7 +19,7 @@ for(const pkg of pkgnames.map(parse)) {
   for (const provide of await pantry.getProvides(pkg)) {
     const name = moustaches.apply(provide, versionMap)
     const bin = path.join('bin', name)
-    const sbin = path.join('bin', name)
+    const sbin = path.join('sbin', name)
     if (!bin.isExecutableFile() && !sbin.isExecutableFile()) missing.push([pkg.project, name])
   }
 }


### PR DESCRIPTION
Adds support for moustache versioned bins.

And fix a stupid bug where I don't _actually_ check `sbin`, but rather check `bin` twice.