### PR TITLE
Ensure runtime HOMEs are set

### DIFF
--- a/libexec/stage-test.ts
+++ b/libexec/stage-test.ts
@@ -37,6 +37,8 @@ const dstdir = new Path(flags.dstdir)
 const yml = await pantry.getYAML(pkg).parse()
 const installations = [...deps]
 if (deps.find(x => x.pkg.project == self.pkg.project) === undefined) installations.push(self)
+
+Deno.env.set("HOME", dstdir.string)  //lol side-effects beware!
 const env = await useShellEnv({ installations })
 
 if (!yml.test) throw "no `test` node in package.yml"

--- a/libexec/stage.ts
+++ b/libexec/stage.ts
@@ -44,16 +44,17 @@ if (srcdir.string.includes(" ")) {
 // NOTE we have to in order to get `version.raw` which many pkgymls need
 const pkg = await pantry.resolve(parse(pkgname))
 
+/// assemble build script
+const pantry_sh = await pantry.getScript(pkg, 'build', deps)
+const brewkit = new URL(import.meta.url).path().parent().parent().join("share/brewkit")
+
 /// calc env
+Deno.env.set("HOME", srcdir.string)  //lol side-effects beware!
 const env = await useShellEnv({ installations: deps })
 if (host().platform == 'darwin') env['MACOSX_DEPLOYMENT_TARGET'] = ['11.0']
 
 env['PATH'] ??= []
 env['PATH'].push("/usr/bin", "/bin", usePrefix().join('tea.xyz/v*/bin').string)
-
-/// assemble build script
-const pantry_sh = await pantry.getScript(pkg, 'build', deps)
-const brewkit = new URL(import.meta.url).path().parent().parent().join("share/brewkit")
 
 const text = undent`
   #!/bin/bash

--- a/libexec/stage.ts
+++ b/libexec/stage.ts
@@ -49,8 +49,11 @@ const pantry_sh = await pantry.getScript(pkg, 'build', deps)
 const brewkit = new URL(import.meta.url).path().parent().parent().join("share/brewkit")
 
 /// calc env
+const old_home = Deno.env.get("HOME")
 Deno.env.set("HOME", srcdir.string)  //lol side-effects beware!
 const env = await useShellEnv({ installations: deps })
+Deno.env.set("HOME", old_home!)
+
 if (host().platform == 'darwin') env['MACOSX_DEPLOYMENT_TARGET'] = ['11.0']
 
 env['PATH'] ??= []


### PR DESCRIPTION
Like really this is awful and should be part of useConfig() /cc @ABevier

Which would require us to *not* support `env.FOO` and instead only allow certain keys like `env.HOME` as the first and only one. I can't honestly think of anymore that we would allow off the bat.