### PR TITLE
fix(render)

### DIFF
--- a/share/brewkit/fix-elf.ts
+++ b/share/brewkit/fix-elf.ts
@@ -42,6 +42,7 @@ export default async function fix_rpaths(installation: Installation, pkgs: (Pack
   const skip_rpaths = [
     "go.dev", // skipping because for some reason patchelf breaks the go binary resulting in the only output being: `Segmentation Fault`
     "tea.xyz", // this causes tea to pass -E/--version (and everything else?) directly to deno, making it _too_ much of a wrapper.
+    "render.com", // same as `tea.xyz`
   ]
   if (skip_rpaths.includes(installation.pkg.project)) {
     console.info(`skipping rpath fixes for ${installation.pkg.project}`)


### PR DESCRIPTION
Either Deno or Apple is annoying me. Light reading in no specific order:
- https://github.com/denoland/deno/issues/17753
- https://github.com/denoland/deno/issues/575 (2018)
- https://github.com/denoland/deno/issues/11154
This is basically going to prevent https://github.com/teaxyz/pantry/pull/480 from functioning on Mac; possibly every other Deno compiled binary (tea also fails validation, though it does sign). Zig binaries seem to be similarly affected.