### PR TITLE
avoid duplicate rpath errors

### DIFF
--- a/share/brewkit/fix-machos.rb
+++ b/share/brewkit/fix-machos.rb
@@ -136,7 +136,11 @@ class Fixer
     @file.rpaths.each do |rpath|
       if rpath.start_with? $tea_prefix
         diff = Pathname.new(rpath).relative_path_from(Pathname.new(@file.filename).parent)
-        @file.change_rpath rpath, "@loader_path/#{diff}"
+        if @file.rpaths.include? diff
+          @file.delete_rpath rpath
+        else
+          @file.change_rpath rpath, "@loader_path/#{diff}"
+        end
         dirty = true
       end
     end


### PR DESCRIPTION
Should fix https://github.com/teaxyz/pantry/actions/runs/4648005436/jobs/8225404215

closes https://github.com/teaxyz/pantry/issues/1306

~yanking brewkit 0.16.0 in the interim~ bug apparently present in 0.15.4; unyanking 0.16.0.