### PR TITLE
Change the default github fetch to releases/tags

### DIFF
--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -251,7 +251,7 @@ function escapeRegExp(string: string) {
 
 async function handleComplexVersions(versions: PlainObject): Promise<SemVer[]> {
   const [user, repo, ...types] = validate_str(versions.github).split("/")
-  const type = types?.join("/").chuzzle() ?? 'releases'
+  const type = types?.join("/").chuzzle() ?? 'releases/tags'
 
   const ignore = (() => {
     const arr = (() => {


### PR DESCRIPTION
This is usually a better choice. May cause some breakage though.

/cc @jheider in case the kettle needs updating