### PR TITLE
isolate build/test from local environment

### DIFF
--- a/bin/pkg-build
+++ b/bin/pkg-build
@@ -87,7 +87,7 @@ for PKG in $PKGS; do
 
   gum "# running build"
 
-  $BASH -e "$BUILD_SCRIPT"
+  env -i GITHUB_TOKEN="$GITHUB_TOKEN" "$BASH" --noprofile --norc -e "$BUILD_SCRIPT"
 
   if ! test -d "$PREFIX"; then
     echo "error: nothing installed to \`$PREFIX\`" >&2

--- a/bin/pkg-test
+++ b/bin/pkg-test
@@ -61,7 +61,7 @@ for PKG in $PKGS; do
 
   gum "## running test"
 
-  $BASH -e "$DSTDIR"/xyz.tea.test.sh
+  env -i "$BASH" --noprofile --norc -e "$DSTDIR"/xyz.tea.test.sh
 
   gum "## running audit"
 


### PR DESCRIPTION
When building packages for the pantry, I've noticed my local environment was affecting `pkg test` (for example, [`yadm init`](https://github.com/teaxyz/pantry/blob/42435e892684ea495ba2f06def3b515833e500b1/projects/yadm.io/package.yml#L22) was picking up my own dotfiles repo).

This fix unsets all environment variables before executing the build/test scripts, as well as skips any bashrc files a user may have.
