### PR TITLE
use replaceAll in fixup.ts

### DIFF
--- a/libexec/fixup.ts
+++ b/libexec/fixup.ts
@@ -60,7 +60,7 @@ for (const part of ["share", "lib"]) {
     if (isFile && path.extname() == ".pc") {
       const orig = await path.read()
       const relative_path = pkg_prefix.relative({ to: path.parent() })
-      const text = orig.replace(pkg_prefix.string, `\${pcfiledir}/${relative_path}`)
+      const text = orig.replaceAll(pkg_prefix.string, `\${pcfiledir}/${relative_path}`)
       if (orig !== text) {
         console.verbose({ fixing: path })
         path.write({text, force: true})
@@ -78,7 +78,7 @@ if (cmake.isDirectory()) {
     if (isFile && path.extname() == ".cmake") {
       const orig = await path.read()
       const relative_path = pkg_prefix.relative({ to: path.parent() })
-      const text = orig.replace(pkg_prefix.string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
+      const text = orig.replaceAll(pkg_prefix.string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
       if (orig !== text) {
         console.verbose({ fixing: path })
         path.write({text, force: true})


### PR DESCRIPTION
Once is not enough:

```pc
prefix=${pcfiledir}/../..
exec_prefix=${prefix}
libdir=/opt/abseil.io/v20230125.3.0/lib
includedir=/opt/abseil.io/v20230125.3.0/include

Name: absl_hash
Description: Abseil hash library
URL: https://abseil.io/
Version: 20230125
Requires: absl_bits = 20230125, absl_city = 20230125, absl_config = 20230125, absl_core_headers = 20230125, absl_endian = 20230125, absl_fixed_array = 20230125, absl_function_ref = 20230125, absl_meta = 20230125, absl_int128 = 20230125, absl_strings = 20230125, absl_optional = 20230125, absl_variant = 20230125, absl_utility = 20230125, absl_low_level_hash = 20230125
Libs: -L${libdir}   -labsl_hash
Cflags: -I${includedir} -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -DNOMINMAX
```