### PR TITLE
use `aws` cli for uploads >1GB

### DIFF
--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -98,7 +98,7 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
     body = encode(body)
   }
   // @ts-ignore typescript doesn't narrow the types properly here
-  return retry(()=>bucket.putObject(key, body))
+  return retry(()=>bucket.bucket.putObject(key, body))
 }
 
 //------------------------------------------------------------------------- main

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -8,6 +8,7 @@ args:
   - --allow-read
   - --allow-env
   - --allow-write
+  - --allow-run=aws
 dependencies:
   aws.amazon.com/cli: ^2
 ---*/

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -104,11 +104,12 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
         AWS_DEFAULT_REGION: "us-east-1",
       }
       console.info(cmd)
-      return retry(() => run(cmd, { env, stdout: true, stderr: true, status: true }).then((x) => {
-        console.log("status:", x.status)
-        console.log("stdout:", x.stdout)
-        console.log("stderr:", x.stderr)
-      }))
+      const foo = await run(cmd, { env, stdout: true, stderr: true, status: true })
+      console.error(`status: ${foo.status}`)
+      console.error(`stdout: ${foo.stdout}`)
+      console.error(`stderr: ${foo.stderr}`)
+      return
+      // return retry(() => run(cmd, { env, stdout: true, stderr: true, status: true }))
     }
     body = await Deno.readFile(body.string)
   } else if (typeof body === "string") {

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -9,8 +9,6 @@ args:
   - --allow-env
   - --allow-write
   - --allow-run=aws
-dependencies:
-  aws.amazon.com/cli: ^2
 ---*/
 
 import { Package, PackageRequirement, SemVer, Path, semver, hooks, utils, porcelain } from "tea"
@@ -92,6 +90,7 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
       console.info("large file (>1GB), using aws cli")
       const filename = body.string
       const cmd = [
+        "tea",
         "aws",
         "s3",
         "cp",

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -8,7 +8,7 @@ args:
   - --allow-read
   - --allow-env
   - --allow-write
-depdenencies:
+dependencies:
   aws.amazon.com/cli: ^2
 ---*/
 
@@ -88,9 +88,9 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
   if (body instanceof Path) {
     // For really large files, just kick it to the CLI
     if (Deno.statSync(body.string).size > 1024 * 1024 * 1024) {
-      console.log("large file (>1GB), using aws cli")
+      console.info("large file (>1GB), using aws cli")
       const filename = body.string
-      console.log(["aws", "s3", "cp", filename, `s3://${bucket.name}/${key}`])
+      console.info(["aws", "s3", "cp", filename, `s3://${bucket.name}/${key}`])
       return retry(() => run(["aws", "s3", "cp", filename, `s3://${bucket.name}/${key}`]))
     }
     body = await Deno.readFile(body.string)

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -9,6 +9,8 @@ args:
   - --allow-env
   - --allow-write
   - --allow-run=aws
+dependencies:
+  aws.amazon.com/cli: ^2
 ---*/
 
 import { Package, PackageRequirement, SemVer, Path, semver, hooks, utils, porcelain } from "tea"
@@ -89,9 +91,7 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
     if (Deno.statSync(body.string).size > 1024 * 1024 * 1024) {
       console.info("large file (>1GB), using aws cli")
       const filename = body.string
-      const cmd = [
-        "tea",
-        "aws",
+      const args = [
         "s3",
         "cp",
         filename,
@@ -102,11 +102,10 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
         AWS_SECRET_ACCESS_KEY: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
         AWS_DEFAULT_REGION: "us-east-1",
       }
-      console.info(cmd)
-      const foo = await run(cmd, { env, stdout: true, stderr: true, status: true })
-      console.error(`status: ${foo.status}`)
-      console.error(`stdout: ${foo.stdout}`)
-      console.error(`stderr: ${foo.stderr}`)
+      console.info("aws", args)
+      const cmd = new Deno.Command("aws", { args, env }).spawn()
+      const res = await cmd.status()
+      console.error(`status: ${res}`)
       return
       // return retry(() => run(cmd, { env, stdout: true, stderr: true, status: true }))
     }

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -104,8 +104,10 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
         AWS_DEFAULT_REGION: "us-east-1",
       }
       console.info(cmd)
-      return retry(() => run(cmd, { env, stdout: true, stderr: true }).catch((e) => {
-        console.error("aws call failed:", e)
+      return retry(() => run(cmd, { env, stdout: true, stderr: true, status: true }).then((x) => {
+        console.log("status:", x.status)
+        console.log("stdout:", x.stdout)
+        console.log("stderr:", x.stderr)
       }))
     }
     body = await Deno.readFile(body.string)

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -87,27 +87,21 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
   console.info({ uploading: body, to: key })
   if (!qaRequired) rv.push(`/${key}`)
   if (body instanceof Path) {
-    // For really large files, just kick it to the CLI
-    if (Deno.statSync(body.string).size > 1024 * 1024 * 1024) {
-      console.info("large file (>1GB), using aws cli")
-      const filename = body.string
-      const args = [
-        "s3",
-        "cp",
-        filename,
-        `s3://${bucket.name}/${key}`,
-      ]
-      const env = {
-        AWS_ACCESS_KEY_ID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
-        AWS_SECRET_ACCESS_KEY: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
-        AWS_DEFAULT_REGION: "us-east-1",
-      }
-      return retry(() => {
-        const cmd = new Deno.Command("aws", { args, env }).spawn()
-        return cmd.status
-      })
+    const args = [
+      "s3",
+      "cp",
+      body.string,
+      `s3://${bucket.name}/${key}`,
+    ]
+    const env = {
+      AWS_ACCESS_KEY_ID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
+      AWS_SECRET_ACCESS_KEY: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
+      AWS_DEFAULT_REGION: "us-east-1",
     }
-    body = await Deno.readFile(body.string)
+    return retry(() => {
+      const cmd = new Deno.Command("aws", { args, env }).spawn()
+      return cmd.status
+    })
   } else if (typeof body === "string") {
     body = encode(body)
   }

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -102,12 +102,10 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
         AWS_SECRET_ACCESS_KEY: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
         AWS_DEFAULT_REGION: "us-east-1",
       }
-      console.info("aws", args)
-      const cmd = new Deno.Command("aws", { args, env }).spawn()
-      const res = await cmd.status
-      console.error(`status: ${res}`)
-      return
-      // return retry(() => run(cmd, { env, stdout: true, stderr: true, status: true }))
+      return retry(() => {
+        const cmd = new Deno.Command("aws", { args, env }).spawn()
+        return cmd.status
+      })
     }
     body = await Deno.readFile(body.string)
   } else if (typeof body === "string") {

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -104,7 +104,7 @@ async function put(key_: string, body: string | Path | Uint8Array, bucket: ExtBu
       }
       console.info("aws", args)
       const cmd = new Deno.Command("aws", { args, env }).spawn()
-      const res = await cmd.status()
+      const res = await cmd.status
       console.error(`status: ${res}`)
       return
       // return retry(() => run(cmd, { env, stdout: true, stderr: true, status: true }))


### PR DESCRIPTION
closes #130
closes https://github.com/teaxyz/pantry/issues/2167
closes https://github.com/teaxyz/pantry/issues/2177

proof: https://github.com/teaxyz/pantry/actions/runs/5261282714/jobs/9512823288

(linux+x86-64 uploads are 2.5GB (gz) and 1.5GB (xz))