### PR TITLE
fix(pkg)

### DIFF
--- a/bin/pkg
+++ b/bin/pkg
@@ -5,7 +5,8 @@ set -e
 if test -z "$1"; then
   echo available commands:
   echo
-  find bin -type f | sed -ne 's/^pkg-/pkg /p'
+  d="$(cd "$(dirname "$0")" && pwd)"
+  find "$d" -type f | sed -ne 's/^.*\/pkg-/pkg /p'
   exit 1
 fi
 


### PR DESCRIPTION
Don't think `find bin` could have ever worked without a `cd`.