### PR TITLE
fix-machos.rb handling of bare lib names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - c-ares.org
           - vim.org
           - tea.xyz/gx/cc
+          - boost.org
           # FIXME? requires a darwin platform to run, and needs
           # macOS 12 to test. That'll require a more complex matrix
           # using get-platform.


### PR DESCRIPTION
closes #170

This fixes boost.org rpaths for me, and allows me to build edencommon

Longer explain: boost.org seems to generate just some bare library names for linkages in the same directory. In theory, this would work normally. However, we're turning them into `@rpath/foo.dylib`, which is clearly wrong. This replaces them with `@rpath/file_path/foo.dylib`.