### PR TITLE
tea/cli 1.0.0 drops script YAML FM

### DIFF
--- a/actions/bottle/bottle.ts
+++ b/actions/bottle/bottle.ts
@@ -1,21 +1,4 @@
-#!/usr/bin/env tea
-
-/* ---
-dependencies:
-  gnu.org/tar: ^1.34
-  tukaani.org/xz: ^5
-  zlib.net: 1
-  gnupg.org: ^2
-  deno.land: '>=1.32<1.36.1'
-args:
-  - deno
-  - run
-  - --allow-net
-  - --allow-run
-  - --allow-env
-  - --allow-read
-  - --allow-write
---- */
+#!/usr/bin/env -S tea deno +gnu.org/tar^1.34 +tukaani.org/xz^5 +zlib.net^1 +gnupg.org^2 +deno.land>=1.32<1.36.1 deno run -A
 
 import { encode as base64Encode } from "deno/encoding/base64.ts"
 import { Installation, Path, hooks, utils } from "tea"

--- a/actions/fetch-pr-artifacts/fetch-pr-artifacts.ts
+++ b/actions/fetch-pr-artifacts/fetch-pr-artifacts.ts
@@ -1,15 +1,4 @@
-#!/usr/bin/env tea
-
-/*---
-dependencies:
-  deno.land: '>=1.32<1.36.1'
-args:
-  - deno
-  - run
-  - --allow-net
-  - --allow-env
-  - --allow-write=./artifacts.tgz
----*/
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-write=./artifacts.tgz
 
 /// Test
 /// ./scripts/fetch-pr-artifacts.ts e582b03fe6efedde80f9569403555f4513dbec91

--- a/actions/get-platform/get-platform.ts
+++ b/actions/get-platform/get-platform.ts
@@ -1,15 +1,4 @@
-#!/usr/bin/env tea
-
-/*---
-dependencies:
-  deno.land: '>=1.32<1.36.1'
-args:
-  - deno
-  - run
-  - --allow-read
-  - --allow-env
-  - --allow-write
----*/
+#!/usr/bin/env -S deno run -A
 
 import { utils, hooks } from "tea"
 const { parse, str } = utils.pkg

--- a/actions/has-artifacts/has-artifacts.ts
+++ b/actions/has-artifacts/has-artifacts.ts
@@ -1,14 +1,4 @@
-#!/usr/bin/env tea
-
-/*---
-dependencies:
-  deno.land: '>=1.32<1.36.1'
-args:
-  - deno
-  - run
-  - --allow-net
-  - --allow-env
----*/
+#!/usr/bin/env -S deno run -A
 
 /// Test
 /// ./scripts/has-artifacts.ts e582b03fe6efedde80f9569403555f4513dbec91

--- a/actions/stage-build-artifacts/cache-artifacts.ts
+++ b/actions/stage-build-artifacts/cache-artifacts.ts
@@ -1,15 +1,4 @@
-#!/usr/bin/env tea
-
-/*---
-dependencies:
-  deno.land: '>=1.32<1.36.1'
-args:
-  - deno
-  - run
-  - --allow-net
-  - --allow-read
-  - --allow-env
----*/
+#!/usr/bin/env -S deno run -A
 
 import { utils, Path } from "tea"
 import { S3 } from "s3"

--- a/actions/upload/upload.ts
+++ b/actions/upload/upload.ts
@@ -1,18 +1,4 @@
-#!/usr/bin/env tea
-
-/*---
-args:
-  - deno
-  - run
-  - --allow-net
-  - --allow-read
-  - --allow-env
-  - --allow-write
-  - --allow-run=aws
-dependencies:
-  aws.amazon.com/cli: ^2
-  deno.land: '>=1.32<1.36.1'
----*/
+#!/usr/bin/env -S tea +aws.amazon.com/cli deno run -A
 
 import { Package, PackageRequirement, SemVer, Path, semver, hooks, utils } from "tea"
 import { decode as base64Decode } from "deno/encoding/base64.ts"

--- a/libexec/extract.ts
+++ b/libexec/extract.ts
@@ -1,23 +1,4 @@
-#!/usr/bin/env -S tea -E
-
-/*---
-dependencies:
-  gnu.org/tar: ^1
-  tukaani.org/xz: ^5
-  sourceware.org/bzip2: ^1
-  info-zip.org/unzip: ^6
-args:
-  - deno
-  - run
-  - --allow-net
-  - --allow-read
-  - --allow-run=tar,unzip
-  - --allow-write
-  - --allow-env
----*/
-
-//TODO verify the sha
-//TODO only allow writes to Deno.args[1]
+#!/usr/bin/env -S tea +curl.se +git-scm.org +gnu.org/tar +tukaani.org/xz deno run -A
 
 import { Package, PackageRequirement, Path, utils, hooks } from "tea"
 const { useSourceUnarchiver, usePantry } = hooks

--- a/libexec/fetch.ts
+++ b/libexec/fetch.ts
@@ -1,23 +1,4 @@
-#!/usr/bin/env -S tea -E
-
-/*---
-args:
-  - deno
-  - run
-  - --allow-net
-  - --allow-run=curl,git,tar
-  - --allow-read
-  - --allow-write
-  - --allow-env
-  - --unstable
-dependencies:
-  curl.se: '*'
-  git-scm.org: '*'
-  gnu.org/tar: '*'
-  tukaani.org/xz: '*'
----*/
-
-//TODO verify the sha
+#!/usr/bin/env -S tea +curl.se +git-scm.org +gnu.org/tar +tukaani.org/xz deno run -A
 
 import { hooks, utils, Stowage, Path } from "tea"
 import { parseFlags } from "cliffy/flags/mod.ts"

--- a/share/brewkit/fix-elf.ts
+++ b/share/brewkit/fix-elf.ts
@@ -1,19 +1,7 @@
-#!/usr/bin/env -S tea -E
+#!/usr/bin/env -S tea +nixos.org/patchelf=0.17.2 +darwinsys.com/file^5 deno run -A
 
-/*---
-args:
-  - deno
-  - run
-  - --allow-run
-  - --allow-env
-  - --allow-read
-  - --allow-write={{tea.prefix}}
-dependencies:
-  # FIXME: 0.18.0 has a regression that breaks libraries
-  # https://github.com/NixOS/patchelf/issues/492#issuecomment-1561912775
-  nixos.org/patchelf: =0.17.2
-  darwinsys.com/file: 5
----*/
+// FIXME ^^ patchelf 0.18.0 has a regression that breaks libraries
+//       https://github.com/NixOS/patchelf/issues/492#issuecomment-1561912775
 
 import { utils, PackageRequirement, Installation, Package, hooks, Path } from "tea"
 import { backticks } from "../../lib/utils.ts"

--- a/share/brewkit/fix-machos.rb
+++ b/share/brewkit/fix-machos.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# using macOS provided ruby is complex, ocassionally breaks and that causes revlock
+# using macOS provided ∵ ruby is complex, ocassionally breaks and that causes revlock
 # ideally our tests would be thorough enough to guarantee more stability
 # we’ll get there…
 

--- a/share/brewkit/fix-shebangs.ts
+++ b/share/brewkit/fix-shebangs.ts
@@ -1,14 +1,4 @@
-#!/usr/bin/env -S tea -E
-
-/* ---
-args:
-  - deno
-  - run
-  - --allow-run
-  - --allow-env
-  - --allow-read
-  - --allow-write={{tea.prefix}}
---- */
+#!/usr/bin/env -S deno run -A
 
 import { Path } from "tea"
 import undent from "outdent"

--- a/share/brewkit/python-venv.py
+++ b/share/brewkit/python-venv.py
@@ -1,10 +1,4 @@
-#!/usr/bin/env tea
-
-#---
-# dependencies:
-#   git-scm.org: ^2
-#   # ^^ required to set version tag used by setup tools
-#---
+#!/usr/bin/env -S tea +git-scm.org python
 
 import argparse
 import os

--- a/share/brewkit/python-venv.sh
+++ b/share/brewkit/python-venv.sh
@@ -1,12 +1,6 @@
-#!/usr/bin/env tea
+#!/usr/bin/env -S tea +git-scm.org bash
 
-#---
-# dependencies:
-#   git-scm.org: ^2
-#   # ^^ required to set version tag used by setup tools
-#---
-
-set -ex
+set -eo pipefail
 
 CMD_NAME=$(basename "$1")
 PREFIX="$(dirname "$(dirname "$1")")"


### PR DESCRIPTION
the rationale is that you can specify all of this info in the shebang line and that requires the end user to learn less new things.

Especially since 1.0 allows `+pkg` syntax specifying the provides, eg. `+git` these lines become really succinct and nice.

Sadly we must specify FQD syntax here because brewkit must be backwards compatible.