### PR TITLE
release without pre-release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,8 @@
 on:
-  release:
-    types:
-      - created
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
 
 concurrency:
   group: ${{ github.event.release.tag_name }}
@@ -11,45 +12,42 @@ permissions:
   contents: read
 
 jobs:
-  verify-prerelease:
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "we only publish pre-releases!" >&2
-          exit 1
-        if: ${{ ! github.event.release.prerelease }}
-
   qa:
-    needs: verify-prerelease
-    if: ${{ github.event.release.prerelease }}
     uses: ./.github/workflows/ci.yml
+  shellcheck:
+    uses: ./.github/workflows/shellcheck.yml
 
   publish:
-    needs: qa
+    needs: [qa, shellcheck]
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-      - name: strip prerelease component
-        run: echo "v=${V%%-rc}" >> $GITHUB_OUTPUT
-        id: strip
-        env:
-          V: ${{ github.event.release.tag_name }}
+      - uses: teaxyz/setup@v0
 
-      - name: Convert pre-release to release
+      - name: determine previous version
+        id: previous
         run: |
-          curl -fX PATCH \
-            -H "Authorization: Bearer ${{ github.token }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -d '{"draft": false, "prerelease": false, "make_latest": true, "tag_name": "${{ steps.strip.outputs.v }}"}' \
-            "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}"
+          versions="$(git tag | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+')"
+          v_latest="$(npx -- semver $versions | tail -n1)"
+          echo "version=$v_latest" >> $GITHUB_OUTPUT
 
-      # delete pre-release tag
-      - run: |
-          git push origin :${{ github.event.release.tag_name }}
-          git tag -d ${{ github.event.release.tag_name }}
+      - name: sanity
+        run:
+          tea semverator lt ${{ steps.previous.outputs.version }} ${{ github.event.inputs.version }}
+
+      - run: gh release create
+          ${{ github.event.inputs.version }}
+          --latest
+          --generate-notes
+          --notes-start-tag=${{ steps.previous.outputs.version }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       # we need the new tag for the next step
       - run: git tag ${{ steps.strip.outputs.v }}

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ V=$(git describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*")
 V=$(tea semverator bump $V $PRIORITY)
 
 git push origin main
-tea gh release create "v$V"-rc --prerelease --generate-notes --title "v$V"
+
+gh workflow run cd.yml --raw-field version="$V"
 ```
 
 


### PR DESCRIPTION
Creating a pre-release before “un-pre-releasing” it is not proper. The pre-release flag is mean to convey eg. `alpha`, `beta`.

The ideal flow IMO is we create a _draft_ release and then github actions takes over.

However in their infinite wisdom GitHub decided that creating draft releases cannot trigger workflows 😒

So instead we convert `cd.yml` to a worfklow dispatch and remove the pre-release step.

---

Having written this I actually disagree with myself, pre-release will do. The only advantage of what I wrote here is that we correctly calculate the previous tag so the generated release notes are correct rather than it always comparing with the `v0` tag.