### PR TITLE
```pkg build``` fixes

### DIFF
--- a/libexec/fixup.ts
+++ b/libexec/fixup.ts
@@ -20,7 +20,7 @@ const pkg_prefix = new Path(unknown[0])
 
 switch (host().platform) {
 case 'darwin': {
-  const cmd = new Deno.Command(Deno.execPath(), {
+  const { output } = new Deno.Command(Deno.execPath(), {
     args: [
       'fix-machos.rb',
       pkg_prefix.string,
@@ -30,21 +30,21 @@ case 'darwin': {
       GEM_HOME: useConfig().prefix.join('.local/share/ruby/gem').string
     }
   })
-  if (!cmd.output) throw new Error("failed to fix machos")
+  if (!output) throw new Error("failed to fix machos")
 } break
 
 case 'linux': {
   const raw = flags.deps == true ? '' : flags.deps as string
   const installs = await Promise.all(raw.split(/\s+/).map(path => cellar.resolve(new Path(path))))
   const deps = installs.map(({ pkg }) => str(pkg))
-  const cmd = new Deno.Command(Deno.execPath(), {
+  const { output } = new Deno.Command(Deno.execPath(), {
     args: [
       'fix-elf.ts',
       pkg_prefix.string,
       ...deps
     ],
   })
-  if (!cmd.output) Deno.exit(1)
+  if (!output) Deno.exit(1)
   break
 }}
 

--- a/libexec/fixup.ts
+++ b/libexec/fixup.ts
@@ -20,8 +20,8 @@ const pkg_prefix = new Path(unknown[0])
 
 switch (host().platform) {
 case 'darwin': {
-  const { success } = await Deno.run({
-    cmd: [
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: [
       'fix-machos.rb',
       pkg_prefix.string,
       ...['bin', 'sbin', 'tbin', 'lib', 'libexec'].compact(x => pkg_prefix.join(x).isDirectory()?.string)
@@ -29,22 +29,22 @@ case 'darwin': {
     env: {
       GEM_HOME: useConfig().prefix.join('.local/share/ruby/gem').string
     }
-  }).status()
-  if (!success) throw new Error("failed to fix machos")
+  })
+  if (!cmd.output) throw new Error("failed to fix machos")
 } break
 
 case 'linux': {
   const raw = flags.deps == true ? '' : flags.deps as string
   const installs = await Promise.all(raw.split(/\s+/).map(path => cellar.resolve(new Path(path))))
   const deps = installs.map(({ pkg }) => str(pkg))
-  const { success } = await Deno.run({
-    cmd: [
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: [
       'fix-elf.ts',
       pkg_prefix.string,
       ...deps
-    ]
-  }).status()
-  if (!success) Deno.exit(1)
+    ],
+  })
+  if (!cmd.output) Deno.exit(1)
   break
 }}
 

--- a/libexec/fixup.ts
+++ b/libexec/fixup.ts
@@ -20,9 +20,8 @@ const pkg_prefix = new Path(unknown[0])
 
 switch (host().platform) {
 case 'darwin': {
-  const { output } = new Deno.Command(Deno.execPath(), {
+  const { output } = new Deno.Command('fix-machos.rb', {
     args: [
-      'fix-machos.rb',
       pkg_prefix.string,
       ...['bin', 'sbin', 'tbin', 'lib', 'libexec'].compact(x => pkg_prefix.join(x).isDirectory()?.string)
     ],

--- a/share/brewkit/fix-machos.rb
+++ b/share/brewkit/fix-machos.rb
@@ -1,8 +1,6 @@
 #!pkgx +gem ruby
 
-# using macOS provided ∵ ruby is complex, ocassionally breaks and that causes revlock
-# ideally our tests would be thorough enough to guarantee more stability
-# we’ll get there…
+# using pkgx ruby to try and avoid macos Ruby complexity
 
 require 'bundler/inline'
 

--- a/share/brewkit/fix-machos.rb
+++ b/share/brewkit/fix-machos.rb
@@ -1,4 +1,4 @@
-#!pkgx +gem ruby
+#!/usr/bin/env -S pkgx +gem ruby
 
 # using pkgx ruby to try and avoid macos Ruby complexity
 

--- a/share/brewkit/fix-machos.rb
+++ b/share/brewkit/fix-machos.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!pkgx +gem ruby
 
 # using macOS provided ∵ ruby is complex, ocassionally breaks and that causes revlock
 # ideally our tests would be thorough enough to guarantee more stability


### PR DESCRIPTION
based on the knowledge shared here: https://github.com/pkgxdev/brewkit/issues/185#issuecomment-1752838117
I was able to get pantry packages building with the couple small changes here.
Using shebang #!pkgx +gem ruby did not initially fix the errors I was seeing. I then updated the deprecated deno.run commands being used and that together with the new shebang brought success.