### PR TITLE
Invoke test script directly

### DIFF
--- a/bin/pkg-test
+++ b/bin/pkg-test
@@ -54,15 +54,9 @@ for PKG in $PKGS; do
 
   stage-test.ts "$PKG" --deps "$DEPS" --dstdir "$DSTDIR"
 
-  if command -v bash >/dev/null; then
-    BASH=bash
-  else
-    BASH="pkgx bash"
-  fi
-
   gum "## running test"
 
-  env -i "$BASH" --noprofile --norc -e "$DSTDIR"/dev.pkgx.test.sh
+  "$DSTDIR"/dev.pkgx.test.sh
 
   gum "## running audit"
 


### PR DESCRIPTION
Invoking it with these args stops the command not found handler running. I don’t understand why it has that effect.

Also I just don’t know why we would invoke it this way. We clearly were surprised about that in the way that the shebang is defined as a pkgx shebang suggesting we also always want to use our own bash.