### PR TITLE
feat(usePantry): Add support for multiple dists in `distributable`.

### DIFF
--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -111,7 +111,7 @@ const getDistributable = async (pkg: Package) => {
     let urlstr = getRawDistributableURL(dist);
     if (!urlstr) continue;
 
-    const v = pkg.version
+    let v = pkg.version
     const stripComponents = flatmap(dist["strip-components"], coerceNumber)
 
     if (isPlainObject(dist)) {

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -94,8 +94,8 @@ const getDistributable = async (pkg: Package) => {
 
   const yml = await hooks.usePantry().project(pkg).yaml();
   const dists = isArray(yml.distributable) ? yml.distributable : [yml.distributable]
-  if (!dists) return;
   for (const dist of dists) {
+    if (!dist) continue;
     //FIXME: Add check for Git dists as well
     if (dist.git) {
       console.warn(

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -115,7 +115,7 @@ const getDistributable = async (pkg: Package) => {
     let tmp_stripComponents: number | undefined;
     if (isPlainObject(dist)) {
       tmp_stripComponents = flatmap(dist["strip-components"], coerceNumber);
-      if (Object.keys(dist.rewrite).length) {
+      if (dist.rewrite?.match) {
         raw_v = pkg.version.raw.replace(
           new RegExp(dist.rewrite["match"], "gi"),
           dist.rewrite["with"],

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -94,7 +94,7 @@ const getDistributable = async (pkg: Package) => {
 
   const yml = await hooks.usePantry().project(pkg).yaml();
   const dists = isArray(yml.distributable) ? yml.distributable : [yml.distributable]
-  if (!dists) = [];
+  if (!dists) dists = [];
   for (const dist of dists) {
     //FIXME: Add check for Git dists as well
     if (dist.git) {

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -95,6 +95,7 @@ const getDistributable = async (pkg: Package) => {
   const yml = await hooks.usePantry().project(pkg).yaml();
   let final_url = "";
   let dists = yml.distributable;
+  if (!dists) dists = [];
   let stripComponents: number | undefined;
   if (!isArray(dists)) dists = [dists];
   for (const dist of dists) {

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -94,6 +94,7 @@ const getDistributable = async (pkg: Package) => {
 
   const yml = await hooks.usePantry().project(pkg).yaml();
   const dists = isArray(yml.distributable) ? yml.distributable : [yml.distributable]
+  if (!dists) = [];
   for (const dist of dists) {
     //FIXME: Add check for Git dists as well
     if (dist.git) {
@@ -121,7 +122,7 @@ const getDistributable = async (pkg: Package) => {
         );
       }
 
-      if (dist?.if) {
+      if (dist.if) {
         const matched = new RegExp(dist.if).test(pkg.version.raw);
         if (!matched) continue
       }

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -116,10 +116,26 @@ const getDistributable = async (pkg: Package) => {
 
     if (isPlainObject(dist)) {
       if (dist.rewrite?.match) {
-        v.raw = v.raw.replace(
+        const v_raw = v.raw.replace(
           new RegExp(dist.rewrite["match"], "gi"),
           dist.rewrite["with"],
         );
+        v = {
+        raw: v_raw,
+        major: pkg.version.major,
+        minor: pkg.version.minor,
+        patch: pkg.version.patch,
+        components: pkg.version.components,
+        prerelease: pkg.version.prerelease,
+        build: pkg.version.build,
+        eq: pkg.version.eq,
+        neq: pkg.version.neq,
+        gt: pkg.version.gt,
+        gte: pkg.version.gte,
+        lt: pkg.version.lt,
+        lte: pkg.version.lte,
+        compare: pkg.version.compare,
+      }
       }
 
       if (dist.if) {

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -94,7 +94,7 @@ const getDistributable = async (pkg: Package) => {
 
   const yml = await hooks.usePantry().project(pkg).yaml();
   const dists = isArray(yml.distributable) ? yml.distributable : [yml.distributable]
-  if (!dists) dists = [];
+  if (!dists) return;
   for (const dist of dists) {
     //FIXME: Add check for Git dists as well
     if (dist.git) {

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -157,6 +157,8 @@ const getDistributable = async (pkg: Package) => {
       final_url = urlstr;
       stripComponents = tmp_stripComponents;
       break;
+    } else {
+      console.warn(`brewkit: Could not fetch ${urlstr} [${rsp.status}]`)
     }
   }
   if (!final_url) return;

--- a/lib/usePantry.ts
+++ b/lib/usePantry.ts
@@ -1,5 +1,5 @@
 import { isNumber, isPlainObject, isString, isArray, PlainObject } from "is-what"
-import { Package, PackageRequirement, semver, utils, hooks } from "libpkgx"
+import { Package, PackageRequirement, SemVer, semver, utils, hooks } from "libpkgx"
 import { getScript } from "./usePantry.getScript.ts"
 import getVersions from "./usePantry.getVersions.ts"
 

--- a/libexec/extract.ts
+++ b/libexec/extract.ts
@@ -19,8 +19,7 @@ const { flags: { outputDir, pkg: pkgname }, unknown } = parseFlags(Deno.args, {
 
 const pantry = usePantry()
 
-let pkg: Package | PackageRequirement = utils.pkg.parse(pkgname)
-pkg = { project: pkg.project, version: pkg.constraint.single() ?? panic() }
+const pkg: Package | PackageRequirement = await usePantry().resolve(utils.pkg.parse(pkgname)) ?? panic
 
 const dstdir = Path.cwd().join(outputDir)
 

--- a/libexec/query.ts
+++ b/libexec/query.ts
@@ -40,7 +40,7 @@ if (versions) {
   Deno.exit(0)
 }
 
-const {version} = await usePantry().resolve(pkg) ?? panic()
+const version = pkg.constraint.single() ?? panic()
 pkg = {project: pkg.project, version }
 
 if (src) {

--- a/libexec/query.ts
+++ b/libexec/query.ts
@@ -40,7 +40,7 @@ if (versions) {
   Deno.exit(0)
 }
 
-const version = pkg.constraint.single() ?? panic()
+const {version} = await usePantry().resolve(pkg) ?? panic()
 pkg = {project: pkg.project, version }
 
 if (src) {

--- a/libexec/query.ts
+++ b/libexec/query.ts
@@ -40,7 +40,10 @@ if (versions) {
   Deno.exit(0)
 }
 
-const version = pkg.constraint.single() ?? panic()
+//FIXME: There might be a better way of doing this. It retains the current behaviour for normal cases and fixes the version.raw for those which don't match
+const pkg_version = pkg.constraint.single() ?? panic()
+const pantry_ver = await usePantry().resolve(pkg) ?? panic()
+const version = (pkg_version.raw == pantry_ver.version.raw) ? pkg_version : pantry_ver.version
 pkg = {project: pkg.project, version }
 
 if (src) {


### PR DESCRIPTION
This PR makes `distributable` key take multiple (and conditional) dists.
For example:
```yml
distributable:
    - url: https://downloads.sourceforge.net/project/cscope/cscope/v{{version.raw}}/cscope-{{version.raw}}.tar.gz
      strip-components: 1
    - url: https://downloads.sourceforge.net/project/cscope/cscope/v{{version.raw}}/cscope-{{version.raw}}.tar.bz2
      strip-components: 1
```
Only the topmost available (200 OK) dist will be used.
This PR also adds support for version conditions (RegExp-based) and temporary rewrites. Such as:
```yml
distributable:
    - url: https://github.com/opentofu/opentofu/archive/refs/tags/v{{version.raw}}.tar.gz
      strip-components: 1
      if: ^(\d+)\.(\d+)\.(\d+)\.(\d+)$ # If the version matches this regex
      rewrite:
          # For example, 1.6.0.3 becomes 1.6.0-alpha3
          match: ^(\d+)\.(\d+)\.(\d+)\.(\d+)$
          with: $1.$2.$3-alpha$4
    - url: https://github.com/opentofu/opentofu/archive/refs/tags/v{{version.raw}}.tar.gz # For future, when it has stable releases (so manually changing it wouldn't be needed)
      strip-components: 1
```