### PR TITLE
redo toolchain links

### DIFF
--- a/libexec/stage.ts
+++ b/libexec/stage.ts
@@ -75,13 +75,17 @@ if (use_cc_shims) {
       }
     }
 
-    symlink(["cc", "gcc", "clang"], {to: "clang"})
-    symlink(["c++", "g++", "clang++"], {to: "clang++"})
+    symlink(["cc", "clang"], {to: "clang"})
+    symlink(["c++", "clang++"], {to: "clang++"})
     symlink(["cpp"], {to: "clang-cpp"})
 
-    symlink(["ld"], {to: "lld"})
-    symlink(["lld"], {to: "lld"})
-    symlink(["ld64.lld"], {to: "ld64.lld"})
+    if (host().platform == "linux") {
+      symlink(["ld"], {to: "ld.lld"})
+    } else if (host().platform == "windows") {
+      symlink(["ld"], {to: "lld-link"})
+    }
+
+    symlink(["ld.lld"], {to: "ld.lld"})
     symlink(["lld-link"], {to: "lld-link"})
 
     symlink(["ar"], {to: "llvm-ar"})

--- a/libexec/stage.ts
+++ b/libexec/stage.ts
@@ -75,8 +75,8 @@ if (use_cc_shims) {
       }
     }
 
-    symlink(["cc", "clang"], {to: "clang"})
-    symlink(["c++", "clang++"], {to: "clang++"})
+    symlink(["cc", "gcc", "clang"], {to: "clang"})
+    symlink(["c++", "g++", "clang++"], {to: "clang++"})
     symlink(["cpp"], {to: "clang-cpp"})
 
     if (host().platform == "linux") {


### PR DESCRIPTION
i think this will fix many of the build issues we've introduced on linux.

- ~removes `gcc`, `g++` links to `clang` (seems to confuse some software)~
- link `ld` to `ld.lld` or `ld-link`
```shell
$ pkgx lld
lld is a generic driver.
Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead
```
- symlink `ld.lld`.
