### PR TITLE
fix-up.ts not catching our new directory names

### DIFF
--- a/.github/workflows/ci.cli.yml
+++ b/.github/workflows/ci.cli.yml
@@ -78,3 +78,13 @@ jobs:
           set +e
           bin/bk build unavailable.com
           test $? -eq 2
+
+  fix-up:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pkgxdev/setup@v2
+      - run: pkgx --sync
+      - run: bin/bk build pc-cmake.com
+      - run: bin/bk test pc-cmake.com
+      - run: bin/bk audit pc-cmake.com

--- a/lib/porcelain/fix-up.ts
+++ b/lib/porcelain/fix-up.ts
@@ -63,7 +63,11 @@ async function fix_pc_files(pkg_prefix: Path) {
       if (isFile && path.extname() == ".pc") {
         const orig = await path.read()
         const relative_path = pkg_prefix.relative({ to: path.parent() })
-        const text = orig.replaceAll(pkg_prefix.string, `\${pcfiledir}/${relative_path}`)
+        // newer versions of brewkit append +brewing to the path; this will get both
+        // variants
+        const text = orig
+          .replaceAll(pkg_prefix.join("+brewing").string, `\${pcfiledir}/${relative_path}`)
+          .replaceAll(pkg_prefix.string, `\${pcfiledir}/${relative_path}`)
         if (orig !== text) {
           console.log({ fixing: path })
           path.write({text, force: true})
@@ -83,7 +87,11 @@ async function fix_cmake_files(pkg_prefix: Path) {
       if (isFile && path.extname() == ".cmake") {
         const orig = await path.read()
         const relative_path = pkg_prefix.relative({ to: path.parent() })
-        const text = orig.replaceAll(pkg_prefix.string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
+        // newer versions of brewkit append +brewing to the path; this will get both
+        // variants
+        const text = orig
+          .replaceAll(pkg_prefix.join("+brewing").string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
+          .replaceAll(pkg_prefix.string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
         if (orig !== text) {
           console.log({ fixing: path })
           path.write({text, force: true})

--- a/lib/porcelain/fix-up.ts
+++ b/lib/porcelain/fix-up.ts
@@ -6,8 +6,8 @@ const { host } = utils
 export default async function finish(config: Config) {
   const prefix = config.path.install
   await fix_rpaths(prefix, config.pkg, config.path.cache, config.deps.gas)
-  await fix_pc_files(prefix)
-  await fix_cmake_files(prefix)
+  await fix_pc_files(prefix, config.path.build_install)
+  await fix_cmake_files(prefix, config.path.build_install)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -52,7 +52,7 @@ async function fix_rpaths(pkg_prefix: Path, pkg: Package, cache: Path, deps: Ins
   }}
 }
 
-async function fix_pc_files(pkg_prefix: Path) {
+async function fix_pc_files(pkg_prefix: Path, build_prefix: Path) {
   //NOTE currently we only support pc files in lib/pkgconfig
   // we aim to standardize on this but will relent if a package is found
   // that uses share and other tools that build against it only accept that
@@ -66,7 +66,7 @@ async function fix_pc_files(pkg_prefix: Path) {
         // newer versions of brewkit append +brewing to the path; this will get both
         // variants
         const text = orig
-          .replaceAll(pkg_prefix.join("+brewing").string, `\${pcfiledir}/${relative_path}`)
+          .replaceAll(build_prefix.string, `\${pcfiledir}/${relative_path}`)
           .replaceAll(pkg_prefix.string, `\${pcfiledir}/${relative_path}`)
         if (orig !== text) {
           console.log({ fixing: path })
@@ -77,7 +77,7 @@ async function fix_pc_files(pkg_prefix: Path) {
   }
 }
 
-async function fix_cmake_files(pkg_prefix: Path) {
+async function fix_cmake_files(pkg_prefix: Path, build_prefix: Path) {
   // Facebook and others who use CMake sometimes rely on a libary's .cmake files
   // being shipped with it. This would be fine, except they have hardcoded paths.
   // But a simple solution has been found.
@@ -90,7 +90,7 @@ async function fix_cmake_files(pkg_prefix: Path) {
         // newer versions of brewkit append +brewing to the path; this will get both
         // variants
         const text = orig
-          .replaceAll(pkg_prefix.join("+brewing").string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
+          .replaceAll(build_prefix.string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
           .replaceAll(pkg_prefix.string, `\${CMAKE_CURRENT_LIST_DIR}/${relative_path}`)
         if (orig !== text) {
           console.log({ fixing: path })

--- a/projects/pc-cmake.com/package.yml
+++ b/projects/pc-cmake.com/package.yml
@@ -1,0 +1,12 @@
+versions:
+  - 1.0.0
+
+build:
+  - run: echo "{{prefix}}" >pc-cmake.pc
+    working-directory: '{{prefix}}/lib/pkgconfig'
+  - run: echo "{{prefix}}" >pc-cmake-targets.cmake
+    working-directory: '{{prefix}}/lib/cmake/pc-cmake'
+
+test:
+  - test "$(cat {{prefix}}/lib/pkgconfig/pc-cmake.pc)" = '${pcfiledir}/../..'
+  - test "$(cat {{prefix}}/lib/cmake/pc-cmake/pc-cmake-targets.cmake)" = '${CMAKE_CURRENT_LIST_DIR}/../../..'


### PR DESCRIPTION
this creates broken .pc and .cmake output.

see: https://github.com/pkgxdev/pantry/actions/runs/7267412014/job/19801705304

there still seems to be 18-24 hour lag when a package rebuild is "seen" by pantry CI, even though the CDN is serving the right package, so this will take time to clear up. :/