### PR TITLE
Allow search for versions directly on npmjs api

### DIFF
--- a/lib/hooks/usePantry.getVersions.test.ts
+++ b/lib/hooks/usePantry.getVersions.test.ts
@@ -1,39 +1,34 @@
-import {
-  assertEquals,
-  assertNotEquals,
-  assertArrayIncludes,
-  assert,
-} from "deno/testing/asserts.ts";
-import { _parse } from "./usePantry.getVersions.ts";
-import { SemVer } from "libpkgx";
+import { assertEquals, assert } from "deno/testing/asserts.ts"
+import { _parse } from "./usePantry.getVersions.ts"
+import { SemVer } from "libpkgx"
 
 Deno.test("versions array", async () => {
-  const foo = await _parse([3, "1.2.3", "v2.3.4"]);
-  assert(foo[0].eq(new SemVer("3.0.0")));
-  assert(foo[1].eq(new SemVer("1.2.3")));
-  assert(foo[2].eq(new SemVer("2.3.4")));
-  assertEquals(foo.length, 3);
-});
+  const foo = await _parse([3, "1.2.3", "v2.3.4"])
+  assert(foo[0].eq(new SemVer("3.0.0")))
+  assert(foo[1].eq(new SemVer("1.2.3")))
+  assert(foo[2].eq(new SemVer("2.3.4")))
+  assertEquals(foo.length, 3)
+})
 
 Deno.test("single version", async () => {
-  const foo = await _parse("3");
-  assert(foo[0].eq(new SemVer("3.0.0")));
-  assertEquals(foo.length, 1);
-});
+  const foo = await _parse("3")
+  assert(foo[0].eq(new SemVer("3.0.0")))
+  assertEquals(foo.length, 1)
+})
 
 Deno.test("complex versions", async () => {
   const foo = await _parse([
     {
-      github: "rust-lang/rls/tags",
+      github: "rust-lang/rls/tags"
     },
     "1.0.1",
-    "1.0.2",
-  ]);
+    "1.0.2"
+  ])
   assert(foo[0].eq(new SemVer("0.125.0"))); // First RLS version
-  assert(foo[foo.length - 3].eq(new SemVer("1.39.0"))); // RLS is no longer maintained and v1.39.0 is the last version available
-  assert(foo[foo.length - 2].eq(new SemVer("1.0.1")));
-  assert(foo[foo.length - 1].eq(new SemVer("1.0.2")));
-});
+  assert(foo[foo.length - 3].eq(new SemVer("1.39.0"))) // RLS is no longer maintained and v1.39.0 is the last version available
+  assert(foo[foo.length - 2].eq(new SemVer("1.0.1")))
+  assert(foo[foo.length - 1].eq(new SemVer("1.0.2")))
+})
 
 Deno.test("npm versions", async () => {
   const versions = await _parse([
@@ -42,13 +37,13 @@ Deno.test("npm versions", async () => {
       ignore: ["9999.0.1", "999.9.9"],
     },
   ]);
-  assertEquals(versions[0], new SemVer("0.7.3"));
+  assert(versions.find((v) => v.eq(new SemVer("0.7.3"))), "0.7.3 should be found");
   assert(
-    versions.filter((v) => v.eq(new SemVer("999.0.1"))).length === 0,
+    versions.find((v) => v.eq(new SemVer("999.0.1"))) === undefined,
     "999.0.1 should be filtered out",
   );
   assert(
-    versions.filter((v) => v.eq(new SemVer("9999.0.1"))).length === 0,
+    versions.find((v) => v.eq(new SemVer("9999.0.1"))) === undefined,
     "9999.0.1 should be filtered out",
   );
 });

--- a/lib/hooks/usePantry.getVersions.test.ts
+++ b/lib/hooks/usePantry.getVersions.test.ts
@@ -1,31 +1,54 @@
-import { assertEquals, assert } from "deno/testing/asserts.ts"
-import { _parse } from "./usePantry.getVersions.ts"
-import { SemVer } from "libpkgx"
+import {
+  assertEquals,
+  assertNotEquals,
+  assertArrayIncludes,
+  assert,
+} from "deno/testing/asserts.ts";
+import { _parse } from "./usePantry.getVersions.ts";
+import { SemVer } from "libpkgx";
 
 Deno.test("versions array", async () => {
-  const foo = await _parse([3, "1.2.3", "v2.3.4"])
-  assert(foo[0].eq(new SemVer("3.0.0")))
-  assert(foo[1].eq(new SemVer("1.2.3")))
-  assert(foo[2].eq(new SemVer("2.3.4")))
-  assertEquals(foo.length, 3)
-})
+  const foo = await _parse([3, "1.2.3", "v2.3.4"]);
+  assert(foo[0].eq(new SemVer("3.0.0")));
+  assert(foo[1].eq(new SemVer("1.2.3")));
+  assert(foo[2].eq(new SemVer("2.3.4")));
+  assertEquals(foo.length, 3);
+});
 
 Deno.test("single version", async () => {
-  const foo = await _parse("3")
-  assert(foo[0].eq(new SemVer("3.0.0")))
-  assertEquals(foo.length, 1)
-})
+  const foo = await _parse("3");
+  assert(foo[0].eq(new SemVer("3.0.0")));
+  assertEquals(foo.length, 1);
+});
 
 Deno.test("complex versions", async () => {
   const foo = await _parse([
     {
-      github: "rust-lang/rls/tags"
+      github: "rust-lang/rls/tags",
     },
     "1.0.1",
-    "1.0.2"
-  ])
+    "1.0.2",
+  ]);
   assert(foo[0].eq(new SemVer("0.125.0"))); // First RLS version
-  assert(foo[foo.length - 3].eq(new SemVer("1.39.0"))) // RLS is no longer maintained and v1.39.0 is the last version available
-  assert(foo[foo.length - 2].eq(new SemVer("1.0.1")))
-  assert(foo[foo.length - 1].eq(new SemVer("1.0.2")))
-})
+  assert(foo[foo.length - 3].eq(new SemVer("1.39.0"))); // RLS is no longer maintained and v1.39.0 is the last version available
+  assert(foo[foo.length - 2].eq(new SemVer("1.0.1")));
+  assert(foo[foo.length - 1].eq(new SemVer("1.0.2")));
+});
+
+Deno.test("npm versions", async () => {
+  const versions = await _parse([
+    {
+      npm: "nx",
+      ignore: ["9999.0.1", "999.9.9"],
+    },
+  ]);
+  assertEquals(versions[0], new SemVer("0.7.3"));
+  assert(
+    versions.filter((v) => v.eq(new SemVer("999.0.1"))).length === 0,
+    "999.0.1 should be filtered out",
+  );
+  assert(
+    versions.filter((v) => v.eq(new SemVer("9999.0.1"))).length === 0,
+    "9999.0.1 should be filtered out",
+  );
+});

--- a/lib/hooks/usePantry.getVersions.ts
+++ b/lib/hooks/usePantry.getVersions.ts
@@ -11,9 +11,9 @@ import useGitHubAPI from "./useGitHubAPI.ts";
 const { validate } = utils;
 
 /// returns sorted versions
-export default async function getVersions(spec: {
-  project: string;
-}): Promise<SemVer[]> {
+export default async function getVersions(
+  spec: { project: string },
+): Promise<SemVer[]> {
   const files = hooks.usePantry().project(spec);
   const versions = await files.yaml().then((x) => x.versions);
   return _parse(versions, spec.project);
@@ -41,7 +41,7 @@ export async function _parse(
       } else {
         const keys = Object.keys(v);
         const first = keys.length > 0 ? keys[0] : "undefined";
-        throw new Error(`Could not parse version scheme for ${first}`);
+        throw new Error(`Could not parse version scheme for ${first}`)
       }
       for (const ver of tempres) {
         result.add(ver);
@@ -171,11 +171,9 @@ interface APIResponseParams {
   strip: (x: string) => string;
 }
 
-async function handleAPIResponse({
-  fetch,
-  ignore,
-  strip,
-}: APIResponseParams): Promise<SemVer[]> {
+async function handleAPIResponse(
+  { fetch, ignore, strip }: APIResponseParams,
+): Promise<SemVer[]> {
   const rv: SemVer[] = [];
   for await (const { version: pre_strip_name, tag } of fetch) {
     let name = strip(pre_strip_name);


### PR DESCRIPTION
After a small discussion on https://github.com/pkgxdev/pantry/pull/4554, I made this PR to allow us to be able to define packages versions as:

```yaml
versions:
  npm: nx
  ignore: ["9999.0.1", "999.9.9"]
```

This will search for versions directly on the [NPM Registry API](https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md).

I do think this is as much pleasant as fetching versions from github and less prone to errors parsing from HTML with `url`. 