### PR TITLE
fix fix-machos

### DIFF
--- a/.github/workflows/ci.cli.yml
+++ b/.github/workflows/ci.cli.yml
@@ -25,6 +25,7 @@ jobs:
           - stark.com/foo@1.2.3
           - git-clone.com
           - pc-cmake.com
+          - fix-machos.com
 
     runs-on: ${{ matrix.platform.os }}
     container: ${{ matrix.platform.img }}

--- a/lib/bin/fix-machos.rb
+++ b/lib/bin/fix-machos.rb
@@ -130,6 +130,10 @@ class Fixer
     # rewrite any rpaths the tool itself set to be relative
     @file.rpaths.each do |rpath|
       if rpath.start_with? $PKGX_DIR
+        if rpath.include? '+brewing'
+          # this is a special case for the brew tool
+          rpath = rpath.sub('+brewing', '')
+        end
         diff = Pathname.new(rpath).relative_path_from(Pathname.new(@file.filename).parent)
         new_rpath = "@loader_path/#{diff}"
         if @file.rpaths.include? new_rpath
@@ -231,6 +235,12 @@ class Fixer
         # assume they are meant to be relative to lib dir
         new_name = Pathname.new($pkg_prefix).join("lib").relative_path_from(Pathname.new(@file.filename).parent)
         new_name = "@loader_path/#{new_name}/#{old_name}"
+      end
+
+      # newer brewkits build in a different path and copy out
+      # so we need to fix that
+      if new_name.include? '+brewing/'
+        new_name = new_name.sub('+brewing/', '/')
       end
 
       @file.change_install_name old_name, new_name

--- a/projects/fix-machos.com/package.yml
+++ b/projects/fix-machos.com/package.yml
@@ -1,0 +1,39 @@
+versions:
+  - 1.0.0
+
+# platforms: [darwin] # not used by our CI, sadly
+
+build:
+  dependencies:
+    zlib.net: ^1
+  script:
+    - mkdir -p "{{prefix}}"/{bin,lib}
+
+    # none of these hacks do anything on linux
+    - run: exit 0
+      if: linux
+
+    - run: |
+        clang -o '{{prefix}}/bin/fix-machos-test' $PROP -lz
+      prop:
+        content: |
+          #include <stdio.h>
+          int main() {
+            printf("Hello, world!\n");
+            return 0;
+          }
+        extname: c
+
+    - cp {{deps.zlib.net.prefix}}/lib/libz.dylib '{{prefix}}/lib'
+
+    - run: install_name_tool -change @rpath/zlib.net/v{{deps.zlib.net.version}}/lib/libz.{{deps.zlib.net.version.marketing}}.dylib {{prefix}}/lib/libz.dylib fix-machos-test
+      working-directory: '{{prefix}}/bin'
+
+    - run: otool -l fix-machos-test
+      working-directory: '{{prefix}}/bin'
+
+test:
+  - run: exit 0
+    if: linux
+  - fix-machos-test
+  - otool -l '{{prefix}}/bin/fix-machos-test' | grep '@loader_path/../../v{{version}}/lib/libz.dylib'


### PR DESCRIPTION
This is required to fix [this](https://github.com/pkgxdev/pantry/actions/runs/7373335441/job/20104553983)

basically `install_name`s that include the `+brewing` path wart aren't getting cleaned up during `fix-machos`.