### PR TITLE
fix-machos: removing +brewing too early breaks change_rpath

### DIFF
--- a/lib/bin/fix-machos.rb
+++ b/lib/bin/fix-machos.rb
@@ -130,12 +130,12 @@ class Fixer
     # rewrite any rpaths the tool itself set to be relative
     @file.rpaths.each do |rpath|
       if rpath.start_with? $PKGX_DIR
-        if rpath.include? '+brewing'
-          # this is a special case for the brew tool
-          rpath = rpath.sub('+brewing', '')
-        end
         diff = Pathname.new(rpath).relative_path_from(Pathname.new(@file.filename).parent)
         new_rpath = "@loader_path/#{diff}"
+        if new_rpath.include? '+brewing'
+          # this is a special case for the brew tool
+          new_rpath = new_rpath.sub('+brewing', '')
+        end
         if @file.rpaths.include? new_rpath
           @file.delete_rpath rpath
         else

--- a/lib/bin/fix-machos.rb
+++ b/lib/bin/fix-machos.rb
@@ -132,8 +132,11 @@ class Fixer
       if rpath.start_with? $PKGX_DIR
         diff = Pathname.new(rpath).relative_path_from(Pathname.new(@file.filename).parent)
         new_rpath = "@loader_path/#{diff}"
+        # this is a special case for the brew tool
+        # FIXME: this is a hack with code smell (magic string)
+        # we should be able to either pass in the build dir, or
+        # redo this whole thing in typescript so we can use config.path.build_install
         if new_rpath.include? '+brewing'
-          # this is a special case for the brew tool
           new_rpath = new_rpath.sub('+brewing', '')
         end
         if @file.rpaths.include? new_rpath
@@ -239,6 +242,9 @@ class Fixer
 
       # newer brewkits build in a different path and copy out
       # so we need to fix that
+      # FIXME: this is a hack with code smell (magic string)
+      # we should be able to either pass in the build dir, or
+      # redo this whole thing in typescript so we can use config.path.build_install
       if new_name.include? '+brewing/'
         new_name = new_name.sub('+brewing/', '/')
       end


### PR DESCRIPTION
Another untested path: change_rpath must be passed the original (builddir) rpath and the new (destdir) rpath; so, I did this logic right at L243 but wrong at L136.

It _seems_ like everything we're doing with fix-machos could be (is?) handled by `install_name_tool`; so the _final form_ of this fix probably involves leaving the ruby behind and handling it in a typescript file where we can use our shiny new `config.path.build_install`. this solves the magic string issue. otherwise, we're looking at passing in the string as an additional argument and increasing complexity in the invocation loop at the bottom. added a couple big ol' `FIXME:`s so we don't forget this evil I have wrought.

until then, this fixes this issue (tested locally against `aws-sdk-cpp`).