### PR TITLE
add allow-sys to cmd/test

### DIFF
--- a/bin/cmd/audit
+++ b/bin/cmd/audit
@@ -1,4 +1,4 @@
-#!//usr/bin/env -S pkgx +git +gh deno run --allow-env --allow-read --allow-run --allow-net --ext=ts
+#!//usr/bin/env -S pkgx +git +gh deno run --allow-env --allow-read --allow-run --allow-net --allow-sys --ext=ts
 
 import { Command } from "cliffy/command/mod.ts"
 import { swallow } from "brewkit/utils.ts"

--- a/bin/cmd/build
+++ b/bin/cmd/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +rsync +git +bash +gum +gh +curl +bzip2 +xz +unzip deno run --ext=ts --allow-env --allow-read --allow-write --allow-run --allow-net
+#!/usr/bin/env -S pkgx +rsync +git +bash +gum +gh +curl +bzip2 +xz +unzip deno run --ext=ts --allow-env --allow-read --allow-write --allow-run --allow-net --allow-sys
 
 import make_build_script from "brewkit/porcelain/build-script.ts"
 import { gum, rsync } from "brewkit/utils.ts"

--- a/bin/cmd/test
+++ b/bin/cmd/test
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +bash +gum +gh +rsync deno run --ext=ts --allow-env --allow-read --allow-write --allow-net --allow-run
+#!/usr/bin/env -S pkgx +bash +gum +gh +rsync deno run --ext=ts --allow-env --allow-read --allow-write --allow-net --allow-run --allow-sys
 
 //TODO net required because we go to github for version info, but really we should require
 // a built product that is then recorded for us to use

--- a/id/id.ts
+++ b/id/id.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +git +gh deno run --allow-env --allow-net --allow-write --allow-run=gh --allow-read
+#!/usr/bin/env -S pkgx +git +gh deno run --allow-env --allow-net --allow-write --allow-sys --allow-run=gh --allow-read
 
 import get_config from "brewkit/config.ts"
 

--- a/lib/actions/platform-key.ts
+++ b/lib/actions/platform-key.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx deno run --allow-env --allow-read
+#!/usr/bin/env -S pkgx deno run --allow-env --allow-read --allow-sys
 
 import { Command } from "cliffy/command/mod.ts"
 import get_config from '../resolve-pkg.ts'

--- a/lib/actions/stage.ts
+++ b/lib/actions/stage.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx deno run --allow-read --allow-env --allow-write
+#!/usr/bin/env -S pkgx deno run --allow-read --allow-env --allow-write --allow-sys
 
 import { hooks, Path } from "pkgx"
 import get_config from '../resolve-pkg.ts'


### PR DESCRIPTION
looks like deno@1.39.2 will require sys permissions to find the host (using Module.cpus).

I _suspect_ all of these invocations will be affected.

ref: https://github.com/pkgxdev/pantry/actions/runs/7416449291/job/20181755668
