### PR TITLE
make cache dir to prevent build failures

### DIFF
--- a/bin/cmd/build
+++ b/bin/cmd/build
@@ -5,7 +5,7 @@ import { gum, rsync } from "brewkit/utils.ts"
 import fix_up from "brewkit/porcelain/fix-up.ts"
 import { Command } from "cliffy/command/mod.ts"
 import fetch from "brewkit/porcelain/fetch.ts"
-import get_config from "brewkit/config.ts"
+import get_config, { platform_cache } from "brewkit/config.ts"
 import { Path, hooks, utils } from "pkgx"
 import * as YAML from "deno/yaml/mod.ts"
 const { useConfig } = hooks
@@ -120,6 +120,8 @@ if (env['GITHUB_TOKEN']) {
   // for `gh`
   env['GH_TOKEN'] = env['GITHUB_TOKEN']
 }
+
+platform_cache(() => config.path.home).mkdir('p')  // we’ve indeed found things to break without this
 
 const proc = new Deno.Command(script.string, {clearEnv: true, env}).spawn()
 const rv = await proc.status

--- a/bin/cmd/test
+++ b/bin/cmd/test
@@ -5,7 +5,7 @@
 
 import { Package, PackageRequirement, Path, hooks, utils } from "pkgx"
 import { gum, find_pkgx, rsync, find_in_PATH } from "brewkit/utils.ts"
-import get_config from "brewkit/config.ts"
+import get_config, { platform_cache } from "brewkit/config.ts"
 import * as YAML from "deno/yaml/mod.ts"
 import undent from "outdent"
 import useConfig from "libpkgx/hooks/useConfig.ts";
@@ -98,6 +98,8 @@ if (env['GITHUB_TOKEN']) {
   // for `gh`
   env['GH_TOKEN'] = env['GITHUB_TOKEN']
 }
+
+platform_cache(() => config.path.home).mkdir('p')  // we’ve indeed found things to break without this
 
 const proc = new Deno.Command(script.string, {clearEnv: true, env}).spawn()
 const rv = await proc.status

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -104,9 +104,9 @@ export default async function config(arg?: string): Promise<Config> {
   }
 }
 
-function platform_cache() {
+export function platform_cache(home = Path.home) {
   return flatmap(Deno.env.get('XDG_CACHE_HOME'), Path.abs) ?? (platform =>
-    platform == 'darwin' ? Path.home().join('Library/Caches') : Path.home().join(".cache")
+    platform == 'darwin' ? home().join('Library/Caches') : home().join(".cache")
   )(host().platform)
 }
 

--- a/projects/version-transformer.com/package.yml
+++ b/projects/version-transformer.com/package.yml
@@ -8,4 +8,10 @@ build:
     echo {{version}} > VERSION
 
 test:
-  test $(cat {{prefix}}/VERSION) = {{version}}
+  - test $(cat {{prefix}}/VERSION) = {{version}}
+
+  # test that cache directories are created in our sandbox
+  - run: touch ~/.cache/foo
+    if: linux
+  - run: touch ~/Library/Caches/foo
+    if: darwin


### PR DESCRIPTION
Some tools don’t think to `mkdir -p` directories that are usually there. Refs https://github.com/pkgxdev/pantry/pull/4807