### PR TITLE
fix `config.ts` for non-arch packages

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -75,7 +75,7 @@ export default async function config(arg?: string): Promise<Config> {
     const dry = await usePantry().getDeps(pkg)
 
     const { pkgs: wet } = await hydrate(dry.runtime.concat(dry.build))
-    let installs = []
+    let installs: { pkg: Package, path: Path }[] = []
 
     try {
       const gas = await plumbing.resolve(wet)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -75,12 +75,18 @@ export default async function config(arg?: string): Promise<Config> {
     const dry = await usePantry().getDeps(pkg)
 
     const { pkgs: wet } = await hydrate(dry.runtime.concat(dry.build))
-    const gas = await plumbing.resolve(wet)
-    // predetermining these just for the build script generation step
-    const installs = gas.pkgs.map(pkg => ({
-      pkg,
-      path: useConfig().prefix.join(pkg.project, `v${pkg.version}`)
-    }))
+    let installs = []
+
+    try {
+      const gas = await plumbing.resolve(wet)
+      // predetermining these just for the build script generation step
+      installs = gas.pkgs.map(pkg => ({
+        pkg,
+        path: useConfig().prefix.join(pkg.project, `v${pkg.version}`)
+      }))
+    } catch {
+      console.warn("Failed to resolve dependencies, will spit out non-dependency config")
+    }
 
     const cache = platform_cache()
     const install =  useConfig().prefix.join(pkg.project, `v${pkg.version}`)


### PR DESCRIPTION
needed for `id.ts` to run successfully.

closes #278