### PR TITLE
use xcode `ar` and `ranlib` if present

### DIFF
--- a/bin/cmd/build
+++ b/bin/cmd/build
@@ -162,21 +162,19 @@ if (ghout) {
 ///////////////////////////////////////////////////////////////////
 function make_toolchain() {
   const deps = new Set(config.deps.dry.build.concat(config.deps.dry.runtime).map(x => x.project))
-  if (deps.has('llvm.org')) {
-    return
-  }
 
-  if (deps.has('gnu.org/gcc')) {
-    if (host().platform == "darwin") {
-      // gnu.org/binutils ar and ranlib seem to seriously mess up darwin builds in
-      // many cases; if xcode ar/ranlib are available, we'll use them
-      if (new Path('/usr/bin/ar').exists() && new Path('/usr/bin/ranlib').exists()) {
+  // gnu.org/binutils ar and ranlib seem to seriously mess up darwin builds in
+  // many cases; if xcode ar/ranlib are available, we'll use them
+  if (deps.has('gnu.org/binutils') &&
+      host().platform == "darwin" &&
+      new Path('/usr/bin/ar').exists() &&
+      new Path('/usr/bin/ranlib').exists()) {
         const d = config.path.home.join('toolchain').mkdir('p')
         d.join('ar').ln('s', { target: '/usr/bin/ar' })
         d.join('ranlib').ln('s', { target: '/usr/bin/ranlib' })
-        return
-      }
-    }
+  }
+
+  if (deps.has('llvm.org') || deps.has('gnu.org/gcc')) {
     return
   }
 

--- a/bin/cmd/build
+++ b/bin/cmd/build
@@ -162,7 +162,21 @@ if (ghout) {
 ///////////////////////////////////////////////////////////////////
 function make_toolchain() {
   const deps = new Set(config.deps.dry.build.concat(config.deps.dry.runtime).map(x => x.project))
-  if (deps.has('llvm.org') || deps.has('gnu.org/gcc')) {
+  if (deps.has('llvm.org')) {
+    return
+  }
+
+  if (deps.has('gnu.org/gcc')) {
+    if (host().platform == "darwin") {
+      // gnu.org/binutils ar and ranlib seem to seriously mess up darwin builds in
+      // many cases; if xcode ar/ranlib are available, we'll use them
+      if (new Path('/usr/bin/ar').exists() && new Path('/usr/bin/ranlib').exists()) {
+        const d = config.path.home.join('toolchain').mkdir('p')
+        d.join('ar').ln('s', { target: '/usr/bin/ar' })
+        d.join('ranlib').ln('s', { target: '/usr/bin/ranlib' })
+        return
+      }
+    }
     return
   }
 

--- a/bin/cmd/build
+++ b/bin/cmd/build
@@ -163,17 +163,6 @@ if (ghout) {
 function make_toolchain() {
   const deps = new Set(config.deps.dry.build.concat(config.deps.dry.runtime).map(x => x.project))
 
-  // gnu.org/binutils ar and ranlib seem to seriously mess up darwin builds in
-  // many cases; if xcode ar/ranlib are available, we'll use them
-  if (deps.has('gnu.org/binutils') &&
-      host().platform == "darwin" &&
-      new Path('/usr/bin/ar').exists() &&
-      new Path('/usr/bin/ranlib').exists()) {
-        const d = config.path.home.join('toolchain').mkdir('p')
-        d.join('ar').ln('s', { target: '/usr/bin/ar' })
-        d.join('ranlib').ln('s', { target: '/usr/bin/ranlib' })
-  }
-
   if (deps.has('llvm.org') || deps.has('gnu.org/gcc')) {
     return
   }

--- a/projects/fix-machos.com/package.yml
+++ b/projects/fix-machos.com/package.yml
@@ -26,7 +26,16 @@ build:
 
     - cp {{deps.zlib.net.prefix}}/lib/libz.dylib '{{prefix}}/lib'
 
-    - run: install_name_tool -change @rpath/zlib.net/v{{deps.zlib.net.version}}/lib/libz.{{deps.zlib.net.version.marketing}}.dylib {{prefix}}/lib/libz.dylib fix-machos-test
+    # zlib is weird about its lib versioning it seems
+    # we have to jump through weird hoops to get this test set up
+    - |
+      if test {{deps.zlib.net.version.patch}} = 0; then
+        ZLIB_VERSION={{deps.zlib.net.version.marketing}}
+      else
+        ZLIB_VERSION={{deps.zlib.net.version}}
+      fi
+
+    - run: install_name_tool -change @rpath/zlib.net/v{{deps.zlib.net.version}}/lib/libz.${ZLIB_VERSION}.dylib {{prefix}}/lib/libz.dylib fix-machos-test
       working-directory: '{{prefix}}/bin'
 
     - run: otool -l fix-machos-test
@@ -36,4 +45,5 @@ test:
   - run: exit 0
     if: linux
   - fix-machos-test
+  - otool -l '{{prefix}}/bin/fix-machos-test'
   - otool -l '{{prefix}}/bin/fix-machos-test' | grep '@loader_path/../../v{{version}}/lib/libz.dylib'

--- a/projects/fix-machos.com/package.yml
+++ b/projects/fix-machos.com/package.yml
@@ -44,5 +44,4 @@ test:
   - run: exit 0
     if: linux
   - fix-machos-test
-  - otool -l '{{prefix}}/bin/fix-machos-test'
   - otool -l '{{prefix}}/bin/fix-machos-test' | grep '@loader_path/../../v{{version}}/lib/libz.dylib'


### PR DESCRIPTION
fixes #277

this is the shortest path to using `/usr/bin/ar` and `/usr/bin/ranlib` on darwin, if present, in place of `gnu.org/binutils`'s. one alternative would be to simply not ship those files (or replace them with symlinks) in the binutils build script, but that feels a tad off.

other solutions are certainly possibly, including overring env.AR and env.RANLIB, or doing nothing.