### PR TITLE
Avoid printing GITHUB_TOKEN on bk docker

### DIFF
--- a/bin/bk-docker
+++ b/bin/bk-docker
@@ -23,6 +23,7 @@ d="$(cd "$(dirname "$0")/.." && pwd)"
 
 if [ -z "$GITHUB_TOKEN" ]; then
   GITHUB_TOKEN=$(pkgx gh auth token)
+  export GITHUB_TOKEN
 fi
 
 if [ "$1" = --pull ]; then
@@ -77,7 +78,7 @@ exec docker run \
   --volume "$VOLUME_NAME:/root/.pkgx" \
   --env DENO_DIR=/root/.pkgx/.cache/deno \
   --env PKGX_PANTRY_PATH=/work \
-  --env GITHUB_TOKEN=$GITHUB_TOKEN \
+  --env GITHUB_TOKEN \
   --env CLICOLOR_FORCE=1 \
   --workdir /work \
   pkgxdev/pkgx \


### PR DESCRIPTION
This can be very bad, like when sharing the output on some GitHub issue for troubleshooting, one can forget or not realize the token is being displayed in plain text.