### PR TITLE
revert move to upload-artifact@v4

### DIFF
--- a/.github/workflows/ci.actions.yml
+++ b/.github/workflows/ci.actions.yml
@@ -115,7 +115,9 @@ jobs:
           file: ${{ steps.dl.outputs.filename }}
           compression: ${{matrix.compression}}
 
-      - uses: actions/upload-artifact@v4
+      # v4 is buggy on apple
+      # https://github.com/actions/upload-artifact/issues/527
+      - uses: actions/upload-artifact@v3
         with:
           path:  ${{ steps.bottle.outputs.filename }}
           name:  ${{ steps.bottle.outputs.name }}

--- a/.github/workflows/ci.actions.yml
+++ b/.github/workflows/ci.actions.yml
@@ -14,8 +14,12 @@ jobs:
         platform:
           - os: ubuntu-latest
             name: linux
+            arch: x86-64
+          # gha finally added arm runners:
+          # https://github.com/actions/runner-images
           - os: macos-latest
             name: darwin
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +36,7 @@ jobs:
       - run: test ${{ steps.build.outputs.project }} = stark.com/foo
       - run: test ${{ steps.build.outputs.version }} = 2.3.4
       - run: test ${{ steps.build.outputs.platform }} = ${{ matrix.platform.name }}
-      - run: test ${{ steps.build.outputs.arch }} = x86-64
+      - run: test ${{ steps.build.outputs.arch }} = ${{ matrix.platform.arch }}
       - run: test -d ${{ steps.build.outputs.prefix }}
       - run: test $BREWKIT_PKGSPEC = ${{ steps.build.outputs.pkgspec }}
       - run: test $BREWKIT_PREFIX = ${{ steps.build.outputs.prefix }}
@@ -44,7 +48,7 @@ jobs:
     strategy:
       matrix:
         platform-key:
-          - darwin+x86-64
+          - darwin+aarch64
           - null
     runs-on: ubuntu-latest
     env:
@@ -91,7 +95,7 @@ jobs:
       matrix:
         compression: [xz, gz]
         platform:
-          - darwin+x86-64
+          - darwin+aarch64
           - linux+x86-64
     env:
       PKGX_PANTRY_PATH: ${{github.workspace}}/co

--- a/download-build-artifact/action.yml
+++ b/download-build-artifact/action.yml
@@ -63,7 +63,9 @@ runs:
       id: prep
       shell: bash
 
-    - uses: actions/download-artifact@v4
+    # upload-artifact@v4 is buggy on apple, and versions must match
+    # https://github.com/actions/upload-artifact/issues/527
+    - uses: actions/download-artifact@v3
       id: download
       with:
         name: ${{ steps.prep.outputs.artifact-name }}

--- a/upload-build-artifact/action.yml
+++ b/upload-build-artifact/action.yml
@@ -40,7 +40,9 @@ runs:
       id: tar
       shell: bash
 
-    - uses: actions/upload-artifact@v4
+    # v4 is buggy on apple
+    # https://github.com/actions/upload-artifact/issues/527
+    - uses: actions/upload-artifact@v3
       with:
         path: ${{ steps.tar.outputs.path }}
         name: ${{ steps.tar.outputs.name }}


### PR DESCRIPTION
actions/upload-artifact@v4 is buggy on apple runners with large files:

https://github.com/actions/upload-artifact/issues/527

bug: https://github.com/pkgxdev/pantry/actions/runs/10221546438
fix: https://github.com/pkgxdev/pantry/actions/runs/10250486742