### PR TITLE
Various common problems

### DIFF
--- a/.github/workflows/ci.cli.yml
+++ b/.github/workflows/ci.cli.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform:
           - os: ubuntu-latest
-            img: debian:buster-slim
+            img: debian:bullseye-slim
             tag: linux
           - os: macos-latest
             tag: mac
@@ -35,6 +35,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pkgxdev/setup@v2
 
+      # otherwise, we're getting some weird race conditions on CI
+      - run: pkgx --sync
+
       - run: bin/bk build ${{matrix.pkg}}
       - run: bin/bk test ${{matrix.pkg}}
       - run: bin/bk audit ${{matrix.pkg}}
@@ -53,14 +56,13 @@ jobs:
       # check build can run twice, see https://github.com/pkgxdev/brewkit/issues/303
       - run: bin/bk build
 
-
   unit-tests:
     runs-on: ubuntu-latest
     env:
       PKGX_PANTRY_PATH: null
     steps:
       - uses: actions/checkout@v4
-      - uses: pkgxdev/dev@v0
+      - uses: pkgxdev/dev@v1
       - run: deno test --allow-env --allow-net --ignore=.data
         working-directory: lib
 
@@ -69,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pkgxdev/setup@v2
-      - run: pkgx --sync  # FIXME PKGX_PANTRY_PATH causes auto sync to fail
+      - run: pkgx --sync # FIXME PKGX_PANTRY_PATH causes auto sync to fail
       - name: build
         run: |
           set +e

--- a/share/toolchain/shim
+++ b/share/toolchain/shim
@@ -20,8 +20,17 @@ if [ "$(uname)" != Darwin ]; then
   set -a
   eval "$("$pkgx" +llvm.org)"
 
+  if printf "%s\n" "$@" | grep -qxF -- '-shared'; then
+      has_shared=1
+  fi
+
   filtered_args=()
   for arg in "$@"; do
+    # -shared and -pie conflict. libs aren't executables, so accept the -shared
+    if [ "$arg" = "-pie" ] && [ "$has_shared" = "1" ]; then
+        continue
+    fi
+
     if [ "$arg" != -Werror ]; then
       filtered_args+=("$arg")
     fi


### PR DESCRIPTION
- -pie/-shared don't mix; assume -shared is controlling.
- .la files are fully unrelocatable. they should always be removed.
- lib64 > lib merger (certain older linux packages)
- /include header flattening; preserve single subdir by symlink, while also exposing .h files from the /include/