### PR TITLE
fix shim ordering

### DIFF
--- a/lib/porcelain/build-script.ts
+++ b/lib/porcelain/build-script.ts
@@ -51,10 +51,10 @@ export default async function(config: Config, PATH?: Path): Promise<string> {
 
     ${gum} format "## env"
       export PKGX_HOME="$HOME"
-      export PATH="${brewkit_PATHs}:$PATH"
       set -a
       ${env_plus ? `eval "$(CLICOLOR_FORCE=1 ${pkgx} ${env_plus})"` : ''}
       set +a
+      export PATH="${brewkit_PATHs}:$PATH"
 
       export PKGX="${pkgx}"
       export HOME=${config.path.home.string}

--- a/lib/porcelain/fix-up.ts
+++ b/lib/porcelain/fix-up.ts
@@ -124,7 +124,7 @@ async function consolidate_lib64(pkg_prefix: Path) {
   if (!lib64.isDirectory()) return
 
   const lib = pkg_prefix.join("lib")
-  lib.mkpath()
+  Deno.mkdirSync(lib.string, { recursive: true })
 
   for await (const [path, { isFile, isSymlink }] of lib64.ls()) {
     const dest = lib.join(path.basename())


### PR DESCRIPTION
our shims don't _do_ anything if the build deps include a compiler/linker. this breaks all the hard work we do. swap the order
