### PR TITLE
fix-elf: patchelf PT_INTERP to strip +brewing post-install

### DIFF
--- a/lib/bin/fix-elf.ts
+++ b/lib/bin/fix-elf.ts
@@ -24,7 +24,47 @@ export default async function fix_rpaths(installation: Installation, pkgs: strin
   console.info("doing SLOW rpath fixes…")
   for await (const [exename] of exefiles(installation.path)) {
     await set_rpaths(exename, pkgs, installation)
+    await fix_interpreter(exename)
   }
+}
+
+/// Strip the `+brewing` build-prefix suffix from PT_INTERP if present.
+///
+/// brewkit installs into ${prefix}+brewing/ then renames to ${prefix}/.
+/// The build's `ld --dynamic-linker=...+brewing/.../ld-linux*.so` flag
+/// bakes the +brewing path into PT_INTERP of every linked binary.
+/// fix-elf has historically only patched RPATH; without also patching
+/// PT_INTERP, packages whose own bin/ tools have a PT_INTERP that points
+/// back into their own bottle (currently rare — glibc is the obvious
+/// example) become broken after the rename: the kernel tries to load
+/// the .../+brewing/.../ld-linux*.so path which no longer exists.
+///
+/// No-op on binaries whose PT_INTERP doesn't contain `+brewing`, which
+/// is the case for every existing pantry bottle (they consume the host
+/// runner's ld-linux at PT_INTERP=/lib(64)?/ld-linux-*.so).
+async function fix_interpreter(exename: Path) {
+  let cur: string
+  try {
+    cur = (await backticks({
+      cmd: ["patchelf", "--print-interpreter", exename],
+    })).chuzzle() ?? ""
+  } catch {
+    return // not a dynamic ELF, or statically linked, or no PT_INTERP
+  }
+  if (!cur.includes("+brewing")) return
+
+  const fixed = cur.replace(/\+brewing/g, "")
+  // Sanity check: only rewrite to a path that actually exists, otherwise
+  // we'd silently produce a binary that can't be exec'd at all.
+  if (!new Path(fixed).exists()) {
+    console.warn(`fix-elf: PT_INTERP target ${fixed} doesn't exist; skipping rewrite for ${exename}`)
+    return
+  }
+  const proc = new Deno.Command("patchelf", {
+    args: ["--set-interpreter", fixed, exename.string]
+  }).spawn()
+  const { success } = await proc.status
+  if (!success) console.warn(`fix-elf: patchelf --set-interpreter failed for ${exename}`)
 }
 
 


### PR DESCRIPTION
## Summary

brewkit installs each pkg to `${prefix}+brewing/` then renames to `${prefix}/`. The build's `ld --dynamic-linker=...+brewing/.../ld-linux*.so` flag bakes the `+brewing` path into `PT_INTERP` of every linked binary. `fix-elf` has historically only patched **RPATH** via patchelf, leaving `PT_INTERP` referencing a path that no longer exists post-rename.

This is harmless for typical pantry recipes — their binaries' `PT_INTERP` points at the host runner's `/lib(64)?/ld-linux-*.so`, never back into the bottle. So the `+brewing` substring never appears in `PT_INTERP` and there's nothing to fix.

For **low-level packages whose own bottle ships `ld-linux*`** (glibc is the obvious example, future musl bottle would be another), `PT_INTERP` after install is broken — `bin/ld.so`, `bin/getconf`, `bin/iconv` etc. all fail to exec because the kernel can't find the `+brewing` path. This blocks any direct invocation of the bottle's tools in the test phase or by consumers.

## Change

Add a no-op-by-default `fix_interpreter()` step alongside `set_rpaths()`:

```ts
export default async function fix_rpaths(installation: Installation, pkgs: string[]) {
  console.info("doing SLOW rpath fixes…")
  for await (const [exename] of exefiles(installation.path)) {
    await set_rpaths(exename, pkgs, installation)
    await fix_interpreter(exename)   // ← new
  }
}
```

`fix_interpreter()`:
- reads `PT_INTERP` with `patchelf --print-interpreter`
- if it contains `"+brewing"`, rewrites via `patchelf --set-interpreter`
- skips if the rewritten target doesn't exist (guards against bad rewrites)
- catches errors quietly when the file is statically linked / has no `.interp` section (consistent with the existing `set_rpaths` defensive style)

## Compatibility

**No behaviour change for any existing pantry bottle.** They all consume the host runner's `ld-linux` at `PT_INTERP`, so the substring `"+brewing"` never matches and `fix_interpreter()` is a no-op.

## Refs

- pkgxdev/pantry#12968 (gnu.org/glibc PR) — the use case that surfaced this gap. The PR currently works around it with a bash-builtin file-existence test instead of running the bottle's own `ld.so --version` / `getconf --version`. With this brewkit change merged, that workaround can be dropped.
- pkgxdev/pantry#5080 (mxcl's Feb 2024 glibc attempt — same gap, never resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)