### PR TITLE
fix(fix-machos): preserve adhoc flag when re-signing entitled binaries

### DIFF
--- a/lib/bin/fix-machos.rb
+++ b/lib/bin/fix-machos.rb
@@ -76,6 +76,23 @@ class Fixer
     entitlements_xml, _, _ = Open3.capture3("codesign", "-d", "--entitlements", ":-", filename)
     has_entitlements = !entitlements_xml.strip.empty?
 
+    # `--preserve-metadata=flags` does NOT preserve the adhoc flag (0x2)
+    # when re-signing — codesign treats the adhoc bit as identity-derived
+    # rather than a preservable flag. The result is a signed-but-not-adhoc
+    # binary (flags=0x0) which macOS Virtualization.framework rejects when
+    # the binary needs `com.apple.security.virtualization` entitlement
+    # (eg. lima's limactl). See pkgxdev/pantry#7853.
+    #
+    # Fix: when signing ad-hoc (signing_id == "-") and the binary has
+    # entitlements we care about, take the remove+re-sign path directly.
+    # That path uses `--entitlements <file>` instead of --preserve-metadata,
+    # which produces a clean signature with flags=0x2(adhoc) — matching
+    # what `codesign -s -` from the binary's own Makefile would produce.
+    if signing_id == "-" and has_entitlements
+      resign_with_entitlements!(filename, signing_id, entitlements_xml)
+      return
+    end
+
     _, stderr_str, status = Open3.capture3("codesign", "--sign", signing_id, "--force",
                                   "--preserve-metadata=entitlements,requirements,flags,runtime",
                                   filename)
@@ -90,9 +107,13 @@ class Fixer
     # some binaries end up in a state where --preserve-metadata fails
     # strip the signature entirely and re-sign from scratch
     puts "fix-macho: re-signing #{filename} (preserve-metadata failed)"
+    resign_with_entitlements!(filename, signing_id, has_entitlements ? entitlements_xml : nil)
+  end
+
+  def resign_with_entitlements!(filename, signing_id, entitlements_xml)
     Open3.capture3("codesign", "--remove-signature", filename)
 
-    if has_entitlements
+    if entitlements_xml and !entitlements_xml.strip.empty?
       # write entitlements to a tmpfile and re-sign with them
       require 'tempfile'
       tmp = Tempfile.new(['entitlements', '.xml'])


### PR DESCRIPTION
## Summary
- \`--preserve-metadata=entitlements,requirements,flags,runtime\` does NOT preserve the adhoc flag (0x2) when re-signing. codesign treats the adhoc bit as identity-derived rather than a preservable flag, so the result is a signed-but-not-adhoc binary (\`flags=0x0(none)\`).
- This breaks any binary that needs Virtualization.framework entitlements on macOS: the OS rejects \`com.apple.security.virtualization\` access if the binary isn't properly ad-hoc signed. Most visible symptom: lima's \`limactl start <vm>\` with \`vmType: vz\` silently exits with no error when run from pkgx, while the same version from brew works fine. See pkgxdev/pantry#7853.
- Fix: when signing ad-hoc (\`signing_id == "-"\`) AND the binary has entitlements, take the strip-and-re-sign path directly. That path uses \`--entitlements <file>\` instead of \`--preserve-metadata\`, which produces a clean signature with \`flags=0x2(adhoc)\` — matching what \`codesign -s -\` from the binary's own Makefile would produce.
- Extracted the strip-and-re-sign path into a helper (\`resign_with_entitlements!\`) so the two codepaths can't drift.

## Diagnostic before/after

Tested on a pkgx-installed \`limactl\`:

```
before: CodeDirectory v=20400 flags=0x0(none)  location=embedded
after:  CodeDirectory v=20400 flags=0x2(adhoc) location=embedded
```

Entitlements (the 3 lima needs: \`com.apple.security.network.client\`, \`com.apple.security.network.server\`, \`com.apple.security.virtualization\`) are preserved in both cases.

## Test plan
- [ ] Build any darwin recipe whose binary already does its own \`codesign --entitlements\` step (eg. \`lima-vm.io\`)
- [ ] Verify the resulting bottle binary has \`flags=0x2(adhoc)\` set
- [ ] Verify entitlements survive (\`codesign --display --entitlements -\`)
- [ ] Sanity-check non-entitled binaries still get signed correctly (most pkgx bottles)
- [ ] Confirm lima \`limactl start <vm>\` with \`vmType: vz\` works from a freshly-built bottle on macOS 15+ (the primary bug report)

## Risk
- Touches the codesigning logic that runs on every darwin macho file
- Behavior change is narrow: only when (signing_id is ad-hoc) AND (binary has entitlements). Both conditions are required — non-entitled binaries take the original path unchanged
- The fallback path it uses was already in the codebase as the "preserve-metadata failed" branch; this just makes it the primary path for the entitled+ad-hoc case

🤖 Generated with [Claude Code](https://claude.com/claude-code)