### PR TITLE
fix(bkpyvenv): use --copies for relocatable venvs (closes pkgxdev/pantry#8487)

### DIFF
--- a/libexec/bkpyvenv
+++ b/libexec/bkpyvenv
@@ -37,7 +37,13 @@ stage)
     poetry config virtualenvs.create true
     poetry config virtualenvs.in-project true
   else
-    python -m venv "$PREFIX"/venv
+    # --copies: copy the python binary into the venv instead of
+    # symlinking it. With the default --symlinks behavior the resulting
+    # `$PREFIX/venv/bin/python` is an absolute symlink to
+    # `/opt/python.org/v<ver>/bin/python`, which breaks any bottle
+    # installed somewhere other than /opt (eg. /usr/local/pkgs/...
+    # via pkgm). See pkgxdev/pantry#8487 for the original report.
+    python -m venv --copies "$PREFIX"/venv
   fi
   ;;
 seal)


### PR DESCRIPTION
## Summary

`python -m venv` defaults to `--symlinks` on Linux, so `bkpyvenv stage` creates a venv whose `bin/python` is an absolute symlink into the python.org bottle's `/opt/python.org/v<X>/bin/python`. Any bottle installed outside `/opt/` — eg. via pkgm to `/usr/local/pkgs/...` — ends up with a broken venv whose interpreter target doesn't exist.

Pass `--copies` so the python binary is physically copied into the venv instead of symlinked. Same relocation pattern that recipes hand-rolling a venv already use (`pyqt5`'s recipe in pantry calls `python -m venv --copies`).

Closes pkgxdev/pantry#8487.

## Affected recipes (sample)

These currently use `bkpyvenv stage` and so produce non-relocatable venvs today:

- `xpra.org` (the recipe that surfaced #8487)
- Other python-tooling recipes that adopt the helper

## Test plan

- [ ] CI on this PR (brewkit's own test suite)
- [ ] Verify pantry recipe `xpra.org` builds successfully with this brewkit version
- [ ] Verify the resulting `$PREFIX/venv/bin/python` is a regular file, not a symlink

## Tradeoff

`--copies` makes the bottle ~30MB larger per venv (one copy of the python interpreter). The cost is small relative to the typical venv install size, and the bottle becomes pkgm-relocatable, which matches everything else in pantry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)