### PR TITLE
fix(fix-machos): force adhoc signing for virtualization/hypervisor entitlements

### DIFF
--- a/lib/bin/fix-machos.rb
+++ b/lib/bin/fix-machos.rb
@@ -76,6 +76,25 @@ class Fixer
     entitlements_xml, _, _ = Open3.capture3("codesign", "-d", "--entitlements", ":-", filename)
     has_entitlements = !entitlements_xml.strip.empty?
 
+    # Some entitlements (notably `com.apple.security.virtualization` and
+    # `com.apple.security.hypervisor`) require either adhoc signing or a
+    # Developer ID with a matching provisioning profile. When pantry CI
+    # has imported a Developer ID via `apple-actions/import-codesign-certs`,
+    # `signing_id` is that Developer ID — but it generally has no matching
+    # provisioning, so macOS Virtualization.framework / hypervisor.framework
+    # refuse the entitlement at runtime (the binary launches but vz / hv
+    # calls fail). Homebrew sidesteps this by always adhoc-signing these
+    # binaries. Mirror that: force adhoc when these entitlements are present.
+    # See pkgxdev/pantry#7853.
+    privileged_entitlements = %w[
+      com.apple.security.virtualization
+      com.apple.security.hypervisor
+    ]
+    if has_entitlements and privileged_entitlements.any? { |k| entitlements_xml.include?(k) }
+      resign_with_entitlements!(filename, "-", entitlements_xml)
+      return
+    end
+
     # `--preserve-metadata=flags` does NOT preserve the adhoc flag (0x2)
     # when re-signing — codesign treats the adhoc bit as identity-derived
     # rather than a preservable flag. The result is a signed-but-not-adhoc


### PR DESCRIPTION
## Summary

When pantry CI imports a Developer ID via `apple-actions/import-codesign-certs`, brewkit re-signs every Mach-O with that Developer ID. Some entitlements — notably `com.apple.security.virtualization` and `com.apple.security.hypervisor` — require either adhoc signing **or** a Developer ID with a matching provisioning profile. A generic Developer ID without that provisioning is rejected by macOS Virtualization.framework / hypervisor.framework at runtime: the binary launches, but `vz` / `hv` calls fail.

This is the root cause of lima's `limactl` breaking on pkgx bottles while the Homebrew bottle works: Homebrew adhoc-signs these binaries, brewkit was re-signing them with the Tea Inc. Developer ID and losing the entitlement.

## Fix

When these entitlements are present, force adhoc signing rather than using the Developer ID. Mirrors Homebrew's behavior for the same class of binaries.

The check runs **before** the existing #349 fix, so it catches both signing paths (the `signing_id == \"-\"` path is unchanged for non-privileged adhoc work).

## Why a complementary fix to #349

#349 covered the `adhoc -> adhoc` case: when `signing_id == \"-\"`, `--preserve-metadata=flags` was silently dropping the adhoc flag, leaving `flags=0x0`. The fix was to take the remove+re-sign path with `--entitlements`.

But pantry CI uses `signing_id == \"<Developer ID>\"`, so the `if signing_id == \"-\"` guard never fired. The binary went through the standard `--preserve-metadata=...,flags,...` codesign call and ended up signed with the Developer ID (no adhoc flag, no matching provisioning). Verified on the rebuilt `lima-vm.io@2.1.2` bottle: `flags=0x0(none)`, `Authority=Developer ID Application: Tea Inc. (7WV56FL599)`, vz nested virt still failing.

This PR adds a complementary check (privileged-entitlements present → force adhoc) **before** the signing-id-based branch.

## Verification approach

After this lands, rebuilding `lima-vm.io` should produce a bottle with:
- `flags=0x2(adhoc)`
- `Signature=adhoc`
- `TeamIdentifier=not set`

…matching the working Homebrew bottle exactly. Will confirm on M3+/M4 hardware against the `nested.yaml` template from pkgxdev/pantry#7853.

## Test plan

- [ ] Rebuild lima-vm.io on the new brewkit
- [ ] Verify `codesign -dvvv <new bottle>` shows `flags=0x2(adhoc)` and no TeamIdentifier
- [ ] Run `limactl start nested` with `vmType: vz` + `nestedVirtualization: true` on M3+/M4 — should boot the VM without the `vz error: nested virtualization is not supported` fatal

Refs: pkgxdev/pantry#7853

🤖 Generated with [Claude Code](https://claude.com/claude-code)