### PR TITLE
better-pyvenv-fix

### DIFF
--- a/libexec/bkpyvenv
+++ b/libexec/bkpyvenv
@@ -37,13 +37,23 @@ stage)
     poetry config virtualenvs.create true
     poetry config virtualenvs.in-project true
   else
-    # --copies: copy the python binary into the venv instead of
-    # symlinking it. With the default --symlinks behavior the resulting
-    # `$PREFIX/venv/bin/python` is an absolute symlink to
-    # `/opt/python.org/v<ver>/bin/python`, which breaks any bottle
-    # installed somewhere other than /opt (eg. /usr/local/pkgs/...
-    # via pkgm). See pkgxdev/pantry#8487 for the original report.
-    python -m venv --copies "$PREFIX"/venv
+    case "$(uname -s)" in
+      Linux)
+      # --copies: copy the python binary into the venv instead of
+      # symlinking it. With the default --symlinks behavior the resulting
+      # `$PREFIX/venv/bin/python` is an absolute symlink to
+      # `/opt/python.org/v<ver>/bin/python`, which breaks any bottle
+      # installed somewhere other than /opt (eg. /usr/local/pkgs/...
+      # via pkgm). See pkgxdev/pantry#8487 for the original report.
+      python -m venv --copies "$PREFIX"/venv
+      ;;
+      *)
+      # macOS: --copies breaks signed/framework python binaries.
+      # The pkgm-relocation problem #8487 doesn't apply on darwin in
+      # the same way (different runtime resolution)
+      python -m venv "$PREFIX"/venv
+      ;;
+    esac
   fi
   ;;
 seal)


### PR DESCRIPTION
`--copies` breaks darwin:

```
+ git tag -a 9.1.0 -m 'Version 9.1.0' --force
+ unset GIT_DIR
+ '[' '' = poetry ']'
+ python -m venv --copies /opt/pytest.org/v9.1.0+brewing/venv
Error: Command '['/opt/pytest.org/v9.1.0+brewing/venv/bin/python', '-m', 'ensurepip', '--upgrade', '--default-pip']' died with <Signals.SIGABRT: 6>.
```