### PR TITLE
feat(build): Print config logs on build failure if debug verbosity enabled

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -135,7 +135,7 @@ platform_cache(() => config.path.home).mkdir('p')  // we’ve indeed found thing
 const proc = new Deno.Command(script.string, {clearEnv: true, env}).spawn()
 const rv = await proc.status
 if (!rv.success) {
-  // if DEBUG=1 or RUNNER_DEBUG=1, we’ll see the config tool output in the logs
+  // If verbosity is debug (DEBUG=1, or GITHUB_ACTIONS=true with RUNNER_DEBUG=1), print config logs to aid diagnosis
   if (verbosity >= Verbosity.debug) {
     const wanted = new Set(['config.log', 'CMakeError.log', 'CMakeOutput.log', 'meson-log.txt'])
     try {
@@ -147,7 +147,7 @@ if (!rv.success) {
           console.debug(`==== END ${path} ====`)
         }
       }
-    } catch { console.warn("failed to read config logs") }
+    } catch (err) { console.warn("failed to read config logs:", err) }
   }
   throw new Error(`UR BUILD FAILED WITH CODE ${rv.code} & SIGNAL ${rv.signal}`)
 }

--- a/build/build.ts
+++ b/build/build.ts
@@ -6,7 +6,7 @@ import fix_up from "brewkit/porcelain/fix-up.ts"
 import { Command } from "cliffy/command/mod.ts"
 import fetch from "brewkit/porcelain/fetch.ts"
 import get_config, { platform_cache } from "brewkit/config.ts"
-import { Path, hooks, utils } from "pkgx"
+import { Path, hooks, utils, Verbosity, verbosity } from "pkgx"
 import * as YAML from "deno/yaml/mod.ts"
 const { useConfig } = hooks
 const { host } = utils
@@ -134,7 +134,23 @@ platform_cache(() => config.path.home).mkdir('p')  // we’ve indeed found thing
 
 const proc = new Deno.Command(script.string, {clearEnv: true, env}).spawn()
 const rv = await proc.status
-if (!rv.success) throw new Error(`UR BUILD FAILED WITH CODE ${rv.code} & SIGNAL ${rv.signal}`)
+if (!rv.success) {
+  // if DEBUG=1 or RUNNER_DEBUG=1, we’ll see the config tool output in the logs
+  if (verbosity >= Verbosity.debug) {
+    const wanted = new Set(['config.log', 'CMakeError.log', 'CMakeOutput.log', 'meson-log.txt'])
+    try {
+      console.debug("\n==== CONFIG LOGS ====")
+      for await (const [path, { isFile }] of config.path.build.walk()) {
+        if (isFile && wanted.has(path.basename())) {
+          console.debug(`==== START ${path} ====`)
+          console.debug(await path.read())
+          console.debug(`==== END ${path} ====`)
+        }
+      }
+    } catch { console.warn("failed to read config logs") }
+  }
+  throw new Error(`UR BUILD FAILED WITH CODE ${rv.code} & SIGNAL ${rv.signal}`)
+}
 
 /// move installation products to destination
 await gum(`rsync install to final path`)

--- a/lib/pkgx.ts
+++ b/lib/pkgx.ts
@@ -34,9 +34,9 @@ export enum Verbosity {
   trace = 3
 }
 
-(() => {
-  const verbosity = getVerbosity(Deno.env.toObject())
+export const verbosity = getVerbosity(Deno.env.toObject())
 
+;(() => {
   function noop() {}
   if (verbosity < Verbosity.debug) console.debug = noop
   if (verbosity < Verbosity.normal) {


### PR DESCRIPTION
This improves diagnosability for failed builds by surfacing relevant logs automatically when debug verbosity is enabled, reducing the need for manual inspection.
