### PR TITLE
chore: Deno 2 + libpkgx v0.23 (multi-version openssl/abseil)

### DIFF
--- a/audit/action.yml
+++ b/audit/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         echo "::group::fetch deno deps"
         cd $GITHUB_ACTION_PATH
-        pkgx deno^1 cache ./audit.ts
+        pkgx deno^2 cache ./audit.ts
         echo "::endgroup::"
 
     - run: ${GITHUB_ACTION_PATH}/audit.ts '${{ inputs.pkg }}'

--- a/audit/audit.ts
+++ b/audit/audit.ts
@@ -1,6 +1,6 @@
-#!//usr/bin/env -S pkgx +git +gh deno^1 run --allow-env --allow-read --allow-run --allow-net --ext=ts
+#!/usr/bin/env -S pkgx +git +gh deno^2 run --unstable-fs --unstable-ffi --allow-env --allow-read --allow-run --allow-net --ext=ts
 
-import { Command } from "cliffy/command/mod.ts"
+import { Command } from "@cliffy/command"
 import { swallow } from "brewkit/utils.ts"
 import get_config from "brewkit/config.ts"
 import { Package } from "pkgx"

--- a/bin/bk-edit
+++ b/bin/bk-edit
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +deno^1 +git bash
+#!/usr/bin/env -S pkgx +deno^2 +git bash
 
 set -eo pipefail
 

--- a/build/action.yml
+++ b/build/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         echo "::group::fetch deno deps"
         cd $GITHUB_ACTION_PATH
-        pkgx deno^1 cache ./build.ts
+        pkgx deno^2 cache ./build.ts
         echo "::endgroup::"
 
     - name: build

--- a/build/build.ts
+++ b/build/build.ts
@@ -1,13 +1,13 @@
-#!/usr/bin/env -S pkgx +rsync +git +bash +gum +gh +curl +bzip2 +xz +unzip +lzip +column deno^1 run --ext=ts --allow-env --allow-read --allow-write --allow-run --allow-net
+#!/usr/bin/env -S pkgx +rsync +git +bash +gum +gh +curl +bzip2 +xz +unzip +lzip +column deno^2 run --unstable-fs --unstable-ffi --ext=ts --allow-env --allow-read --allow-write --allow-run --allow-net
 
 import make_build_script from "brewkit/porcelain/build-script.ts"
 import { gum, rsync } from "brewkit/utils.ts"
 import fix_up from "brewkit/porcelain/fix-up.ts"
-import { Command } from "cliffy/command/mod.ts"
+import { Command } from "@cliffy/command"
 import fetch from "brewkit/porcelain/fetch.ts"
 import get_config, { platform_cache } from "brewkit/config.ts"
 import { Path, hooks, utils, Verbosity, verbosity } from "pkgx"
-import * as YAML from "deno/yaml/mod.ts"
+import * as YAML from "@std/yaml"
 const { useConfig } = hooks
 const { host } = utils
 
@@ -170,7 +170,7 @@ if (ghout) {
     version: {
       value: config.pkg.version.toString(),
       raw: config.pkg.version.raw,
-      tag: config.pkg.version.tag
+      tag: (config.pkg.version as unknown as { tag?: string }).tag
     }
   })
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,22 +1,29 @@
 {
   "compilerOptions": {
-    "allowJs": false,
     "strict": true
   },
   "lock": false,
   "tasks": {
-    "typecheck": "deno check --unstable $(find . -name '*'.ts)"
+    "typecheck": "deno check --unstable-fs --unstable-ffi $(find . -name '*.ts' ! -name '*.test.ts')"
   },
-  "pkgx": "deno~1.39",  // ^1.40 has unskippable deprecation warnings
+  "pkgx": "deno~2",
   "imports": {
     "brewkit/": "./lib/",
     "is-what": "https://deno.land/x/is_what@v4.1.15/src/index.ts",
     "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
-    "cliffy/": "https://deno.land/x/cliffy@v1.0.0-rc.3/",
+    "@cliffy/command": "jsr:@cliffy/command@^1.0.0",
     "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
-    "deno/": "https://deno.land/std@0.208.0/",
-    "libpkgx": "https://deno.land/x/libpkgx@v0.17.0/mod.ts",
-    "libpkgx/": "https://deno.land/x/libpkgx@v0.17.0/src/",
+    "@std/yaml": "jsr:@std/yaml@^1",
+    "@std/assert": "jsr:@std/assert@^1",
+    // libpkgx multi-version hydrate — JSR (deno.land/x is read-only)
+    // Note: JSR doesn't support trailing-slash import-map prefixes; map each export.
+    "libpkgx": "jsr:@pkgx/libpkgx@^0.24.0",
+    "libpkgx/hooks/useConfig.ts": "jsr:@pkgx/libpkgx@^0.24.0/hooks/useConfig.ts",
+    "libpkgx/hooks/usePantry.ts": "jsr:@pkgx/libpkgx@^0.24.0/hooks/usePantry.ts",
+    "libpkgx/utils/error.ts": "jsr:@pkgx/libpkgx@^0.24.0/utils/error.ts",
+    "libpkgx/utils/host.ts": "jsr:@pkgx/libpkgx@^0.24.0/utils/host.ts",
+    "libpkgx/utils/semver.ts": "jsr:@pkgx/libpkgx@^0.24.0/utils/semver.ts",
+    "libpkgx/plumbing/hydrate.ts": "jsr:@pkgx/libpkgx@^0.24.0/plumbing/hydrate.ts",
     "pkgx": "./lib/pkgx.ts"
   }
 }

--- a/download-build-artifact/action.yml
+++ b/download-build-artifact/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
       run: |
         echo "::group::fetch deno deps"
-        pkgx deno^1 cache ${GITHUB_ACTION_PATH}/../lib/actions/*.ts --config=${GITHUB_ACTION_PATH}/../deno.jsonc
+        pkgx deno^2 cache ${GITHUB_ACTION_PATH}/../lib/actions/*.ts --config=${GITHUB_ACTION_PATH}/../deno.jsonc
         echo "::endgroup::"
 
     - name: prep

--- a/id/action.yml
+++ b/id/action.yml
@@ -30,7 +30,7 @@ runs:
       run: |
         echo "::group::fetch deno deps"
         cd ${GITHUB_ACTION_PATH}
-        pkgx deno^1 cache ./id.ts
+        pkgx deno^2 cache ./id.ts
         echo "::endgroup::"
       shell: bash
 

--- a/id/id.ts
+++ b/id/id.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +git +gh deno^1 run --allow-env --allow-net --allow-write --allow-run=gh,pkgx --allow-read
+#!/usr/bin/env -S pkgx +git +gh deno^2 run --unstable-fs --unstable-ffi --allow-env --allow-net --allow-write --allow-run=gh,pkgx --allow-read
 
 import resolve_pkg from "brewkit/resolve-pkg.ts"
 
@@ -10,8 +10,9 @@ Deno.writeTextFileSync(ghout!, `value=${pkg.version.toString()}\n`, {append: tru
 if (pkg.version.raw) {
   Deno.writeTextFileSync(ghout!, `raw=${pkg.version.raw}\n`, {append: true})
 }
-if (pkg.version.tag) {
-  Deno.writeTextFileSync(ghout!, `tag=${pkg.version.tag}\n`, {append: true})
+const tag = (pkg.version as unknown as { tag?: string }).tag
+if (tag) {
+  Deno.writeTextFileSync(ghout!, `tag=${tag}\n`, {append: true})
 }
 
 const json = {
@@ -19,7 +20,7 @@ const json = {
   version: {
     value: pkg.version.toString(),
     raw: pkg.version.raw,
-    tag: pkg.version.tag
+    tag
   }
 }
 

--- a/lib/actions/platform-key.ts
+++ b/lib/actions/platform-key.ts
@@ -1,6 +1,6 @@
-#!/usr/bin/env -S pkgx deno^1 run --allow-env --allow-read
+#!/usr/bin/env -S pkgx deno^2 run --unstable-fs --unstable-ffi --allow-env --allow-read
 
-import { Command } from "cliffy/command/mod.ts"
+import { Command } from "@cliffy/command"
 import get_config from '../resolve-pkg.ts'
 import { utils } from 'pkgx'
 

--- a/lib/actions/stage.ts
+++ b/lib/actions/stage.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx deno^1 run --allow-read --allow-env --allow-write
+#!/usr/bin/env -S pkgx deno^2 run --unstable-fs --unstable-ffi --allow-read --allow-env --allow-write
 
 import { hooks, Path } from "pkgx"
 import get_config from '../resolve-pkg.ts'

--- a/lib/bin/fix-elf.ts
+++ b/lib/bin/fix-elf.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +nixos.org/patchelf=0.17.2 +darwinsys.com/file^5 deno^1 run -A
+#!/usr/bin/env -S pkgx +nixos.org/patchelf=0.17.2 +darwinsys.com/file^5 deno^2 run --unstable-fs --unstable-ffi -A
 
 // FIXME ^^ patchelf 0.18.0 has a regression that breaks libraries
 //       https://github.com/NixOS/patchelf/issues/492#issuecomment-1561912775
@@ -6,7 +6,7 @@
 import { utils, Installation, hooks, Path } from "pkgx"
 import { backticks } from "../../lib/utils.ts"
 const { useCellar } = hooks
-const { host } = utils
+const { host, compact, chuzzle } = utils
 
 if (import.meta.main) {
   const cellar = useCellar()
@@ -38,12 +38,11 @@ async function set_rpaths(exename: Path, our_rpaths: string[], installation: Ins
   const args = await (async () => {
     //FIXME we need this for perl
     // however really we should just have an escape hatch *just* for stuff that sets its own rpaths
-    const their_rpaths = (await backticks({
-        cmd: ["patchelf", "--print-rpath", exename],
-      }))
-      .split(":")
-      .compact(x => x.chuzzle())
-      //^^ split has ridiculous empty string behavior
+    // split has ridiculous empty string behavior
+    const their_rpaths = compact(
+      (await backticks({ cmd: ["patchelf", "--print-rpath", exename] })).split(":"),
+      x => chuzzle(x),
+    )
 
     const rpaths = [...their_rpaths, ...our_rpaths]
       .map(x => {

--- a/lib/hooks/useCache.test.ts
+++ b/lib/hooks/useCache.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "deno/testing/asserts.ts"
+import { assertEquals } from "@std/assert"
 import { hooks, Path, SemVer } from "pkgx"
 const { useCache } = hooks
 

--- a/lib/hooks/useGitHubAPI.ts
+++ b/lib/hooks/useGitHubAPI.ts
@@ -23,13 +23,12 @@ export default function useGitHubAPI() {
 }
 
 async function gh() {
-  const proc = new Deno.Command("gh", {
+  const { success, stdout } = await new Deno.Command("gh", {
     args: ["auth", "token"],
     stdout: "piped",
-  })
-  const { success } = await proc.spawn().status
+  }).output()
   if (!success) throw new Error("Either set GITHUB_TOKEN or run `gh auth login`")
-  return new TextDecoder().decode((await proc.output()).stdout).trim()
+  return new TextDecoder().decode(stdout).trim()
 }
 
 async function GET2<T>(url: URL | string, headers?: Headers): Promise<[T, Response]> {

--- a/lib/hooks/usePantry.getVersions.test.ts
+++ b/lib/hooks/usePantry.getVersions.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assert } from "deno/testing/asserts.ts"
+import { assertEquals, assert } from "@std/assert"
 import { _parse } from "./usePantry.getVersions.ts"
 import { SemVer } from "libpkgx"
 

--- a/lib/hooks/usePantry.getVersions.ts
+++ b/lib/hooks/usePantry.getVersions.ts
@@ -8,7 +8,7 @@ import {
 import { hooks, SemVer, semver, utils } from "libpkgx";
 import useGitLabAPI from "./useGitLabAPI.ts";
 import useGitHubAPI from "./useGitHubAPI.ts";
-const { validate } = utils;
+const { validate, compact, chuzzle } = utils;
 
 /// returns sorted versions
 export default async function getVersions(
@@ -64,7 +64,7 @@ function escapeRegExp(string: string) {
 
 function handleGitHubVersions(versions: PlainObject): Promise<SemVer[]> {
   const [user, repo, ...types] = validate.str(versions.github).split("/");
-  const type = types?.join("/").chuzzle() ?? "releases/tags";
+  const type = chuzzle(types?.join("/") ?? "") ?? "releases/tags";
 
   const ignore = parseIgnore(versions.ignore);
   const transform = (x => isString(x) ? x : undefined)(versions.transform);
@@ -304,29 +304,37 @@ async function handleTransformer(transform: string, versions: string[]): Promise
   /// sadly deno built binaries cannot `eval` so we have to run a whole script 😕
   //FIXME `eval` is available now!
 
-  const cmd = new Deno.Command("pkgx", {
-    args: ["deno", "run", "-"],
-    stdin: "piped",
-    stdout: "piped",
-  }).spawn()
-
   const vv = versions.map(x => `"${x}"`).join(',')
-
-  const writer = cmd.stdin!.getWriter()
-  await writer.write(new TextEncoder().encode(undent`
+  const script = undent`
     const transform = ${transform}
     for (const v of [${vv}]) {
       const rv = transform(v)
       if (rv) console.log(rv, v)
     }
-    `));
-  await writer.close()
+    `
 
-  const { stdout: out, success: ok } = await cmd.output()
+  const child = new Deno.Command("pkgx", {
+    args: ["deno", "run", "-"],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn()
 
-  if (!ok) throw new Error("failed to run version transformer")
+  // write+close stdin, then drain stdout/stderr and wait — avoids Deno 2 resource leaks
+  {
+    const w = child.stdin.getWriter()
+    await w.write(new TextEncoder().encode(script))
+    await w.close()
+  }
+  const [out, , status] = await Promise.all([
+    new Response(child.stdout).arrayBuffer(),
+    new Response(child.stderr).arrayBuffer(),
+    child.status,
+  ])
 
-  return new TextDecoder().decode(out).split('\n').compact(x => {
+  if (!status.success) throw new Error("failed to run version transformer")
+
+  return compact(new TextDecoder().decode(out).split('\n'), x => {
     const [transformed, original] = x.split(' ')
     const v = semver.parse(transformed)
     if (v) {

--- a/lib/porcelain/build-script.ts
+++ b/lib/porcelain/build-script.ts
@@ -4,7 +4,7 @@ import { Config } from "brewkit/config.ts"
 import undent from "outdent"
 
 const { usePantry, useConfig } = hooks
-const { host } = utils
+const { host, compact } = utils
 
 export default async function(config: Config, PATH?: Path): Promise<string> {
   const depset = new Set(config.deps.gas.map(x => x.pkg.project))
@@ -22,10 +22,10 @@ export default async function(config: Config, PATH?: Path): Promise<string> {
   const gum = find_in_PATH('gum')
 
   const brewkitd = new Path(new URL(import.meta.url).pathname).parent().parent().parent()
-  const brewkit_PATHs = [
-    brewkitd.join("libexec"),
-    PATH
-  ].compact(x => x?.string).join(':')
+  const brewkit_PATHs = compact(
+    [brewkitd.join("libexec"), PATH],
+    x => x?.string,
+  ).join(':')
 
   const FLAGS = flags()
   if (host().platform == 'darwin') {

--- a/lib/porcelain/fetch.ts
+++ b/lib/porcelain/fetch.ts
@@ -82,7 +82,7 @@ async function download(url: URL, dstdir: Path, pkg: Package) {
       const src = useOffLicense('s3').url(stowage)
       return await curl({ dst: tarball, src })
     } catch (err2) {
-      err.cause = err2
+      if (err instanceof Error) err.cause = err2
       throw err
     }
   }

--- a/lib/porcelain/fix-up.ts
+++ b/lib/porcelain/fix-up.ts
@@ -1,7 +1,7 @@
 import { hooks, utils, Path, Package, Installation } from "pkgx"
 import { Config } from "brewkit/config.ts"
 const { usePantry } = hooks
-const { host } = utils
+const { host, compact } = utils
 
 export default async function finish(config: Config) {
   const prefix = config.path.install
@@ -40,7 +40,7 @@ async function fix_rpaths(pkg_prefix: Path, pkg: Package, cache: Path, deps: Ins
     const proc = new Deno.Command(bindir.join('fix-machos.rb').string, {
       args: [
         pkg_prefix.string,
-        ...['bin', 'sbin', 'tbin', 'lib', 'libexec'].compact(x => pkg_prefix.join(x).isDirectory()?.string)
+        ...compact(['bin', 'sbin', 'tbin', 'lib', 'libexec'], x => pkg_prefix.join(x).isDirectory()?.string)
       ],
       env: {
         GEM_HOME: cache.join('brewkit/gem').string

--- a/lib/resolve-pkg.ts
+++ b/lib/resolve-pkg.ts
@@ -1,5 +1,5 @@
 import { Path, utils, hooks, SemVer, semver } from "pkgx"
-const { usePantry } = hooks
+const { usePantry, useConfig } = hooks
 
 export default async function(arg?: string) {
   if (!arg) {
@@ -19,18 +19,40 @@ export default async function(arg?: string) {
       return {
         pkg: {project, version},
         constraint: new semver.Range(`=${version}`),
-        path: found.path
+        path: package_yml_path(found.project, (found as { path?: Path }).path)
       }
     } else {
       const { constraint, project } = utils.pkg.parse(arg.trim())
       const [found, ...rest] = await usePantry().find(project)
       if (rest.length) throw new Error("ambiguous pkg spec")
       const pkg = await usePantry().resolve({project: found.project, constraint})
-      return { constraint, path: found.path, pkg }
+      return {
+        constraint,
+        path: package_yml_path(found.project, (found as { path?: Path }).path),
+        pkg
+      }
     }
   })(arg)
 
   return {pkg, path, constraint}
+}
+
+/// libpkgx≥0.23 `find()` often omits `path` when the project hits the
+/// local pantry cache by directory. Reconstruct package.yml location.
+function package_yml_path(project: string, found?: Path): Path {
+  if (found) return found
+
+  const cfg = useConfig()
+  const prefixes = [
+    ...cfg.pantries,
+    cfg.data.join("pantry/projects"),
+  ]
+  for (const prefix of prefixes) {
+    const p = prefix.join(project, "package.yml")
+    if (p.exists()) return p
+  }
+  // last resort — matches libpkgx default layout
+  return cfg.data.join("pantry/projects", project, "package.yml")
 }
 
 async function get_pantry_status() {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { isArray } from "is-what"
-import { Path } from "pkgx"
+import { Path, utils } from "pkgx"
+const { compact } = utils
 
 export async function backticks({ cmd }: { cmd: Path | (string | Path)[]}): Promise<string> {
   const args = isArray(cmd) ? cmd.map(x => `${x}`) : [cmd.string]
@@ -17,7 +18,7 @@ declare global {
 
 Array.prototype.uniq = function<T>(): Array<T> {
   const set = new Set<T>()
-  return this.compact(x => {
+  return compact(this, x => {
     const s = x.toString()
     if (set.has(s)) return
     set.add(s)

--- a/lib/utils/Unarchiver.ts
+++ b/lib/utils/Unarchiver.ts
@@ -29,7 +29,7 @@ export class TarballUnarchiver extends Unarchiver {
     this.stripComponents = opts.stripComponents
   }
 
-  args(): (string | Path)[] {
+  override args(): (string | Path)[] {
     const args = [
       "tar", "xf", this.opts.zipfile,
       "-C", this.opts.dstdir
@@ -63,7 +63,7 @@ export class ZipUnarchiver extends Unarchiver {
     this.force = opts.force ?? false
   }
 
-  args(): (string | Path)[] {
+  override args(): (string | Path)[] {
     const args = ["unzip"]
     // if (this.opts.verbose) args.push("-v") seems to break it
     if (this.force) args.push("-of")

--- a/libexec/fix-shebangs.ts
+++ b/libexec/fix-shebangs.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx deno^1 run -A
+#!/usr/bin/env -S pkgx deno^2 run --unstable-fs --unstable-ffi -A
 
 import { Path } from "pkgx";
 import undent from "outdent";

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +git +gh +jq +gum +npx +deno^1 bash
+#!/usr/bin/env -S pkgx +git +gh +jq +gum +npx +deno^2 bash
 
 set -eo pipefail
 

--- a/test/action.yml
+++ b/test/action.yml
@@ -17,7 +17,7 @@ runs:
       run: |
         echo "::group::fetch deno deps"
         cd ${GITHUB_ACTION_PATH}
-        pkgx deno^1 cache ./test.ts
+        pkgx deno^2 cache ./test.ts
         echo "::endgroup::"
 
     - name: test

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S pkgx +bash +gum +gh +rsync deno^1 run --ext=ts --allow-env --allow-read --allow-write --allow-net --allow-run
+#!/usr/bin/env -S pkgx +bash +gum +gh +rsync deno^2 run --unstable-fs --unstable-ffi --ext=ts --allow-env --allow-read --allow-write --allow-net --allow-run
 
 //TODO net required because we go to github for version info, but really we should require
 // a built product that is then recorded for us to use
@@ -6,7 +6,7 @@
 import { Package, PackageRequirement, Path, hooks, utils } from "pkgx"
 import { gum, find_pkgx, rsync, find_in_PATH } from "brewkit/utils.ts"
 import get_config, { platform_cache } from "brewkit/config.ts"
-import * as YAML from "deno/yaml/mod.ts"
+import * as YAML from "@std/yaml"
 import undent from "outdent"
 import useConfig from "libpkgx/hooks/useConfig.ts";
 const { usePantry } = hooks

--- a/upload-build-artifact/action.yml
+++ b/upload-build-artifact/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         echo "::group::fetch deno deps"
-        pkgx deno^1 cache ${GITHUB_ACTION_PATH}/../lib/actions/*.ts --config=${GITHUB_ACTION_PATH}/../deno.jsonc
+        pkgx deno^2 cache ${GITHUB_ACTION_PATH}/../lib/actions/*.ts --config=${GITHUB_ACTION_PATH}/../deno.jsonc
         echo "::endgroup::"
 
     # we must tar because the upload action loses file permissions 😕


### PR DESCRIPTION
- Bump runtime from deno^1 to deno^2 with --unstable-fs/ffi
- libpkgx v0.23 via raw.githubusercontent (multi-ABI hydrate)
- cliffy/command and std yaml/assert via JSR
- resolve-pkg: reconstruct package.yml path when find() omits it
- Deno 2 type fixes (override, unknown catch, version.tag)

Enables simple openssl.org: ^3 alongside python's transitive ^1.1.
